### PR TITLE
Build system

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -14,7 +14,10 @@ target_include_directories( Core
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-install (FILES ${lib_headers} DESTINATION include/ComPWA)
+install(FILES ${lib_headers} DESTINATION include/ComPWA)
+install(TARGETS Core
+        LIBRARY DESTINATION lib
+)
 
 # ------ TESTING ----- #
 #Testing routines are stored in separate directory
@@ -28,6 +31,9 @@ foreach(testSrc ${TEST_SRCS})
 
   #Add compile target
   add_executable( ${testName} ${testSrc})
+  #install(TARGETS ${testName}
+  #  RUNTIME DESTINATION bin
+  #)
 
   #link to Boost libraries AND your targets and dependencies
   target_link_libraries( ${testName}

--- a/DataReader/AsciiReader/CMakeLists.txt
+++ b/DataReader/AsciiReader/CMakeLists.txt
@@ -14,3 +14,6 @@ target_include_directories( AsciiReader
 )
 
 install (FILES ${lib_headers} DESTINATION include/ComPWA)
+install(TARGETS AsciiReader
+        LIBRARY DESTINATION lib
+)

--- a/DataReader/CMakeLists.txt
+++ b/DataReader/CMakeLists.txt
@@ -26,6 +26,9 @@ target_include_directories( DataReader
 )
 
 install (FILES ${lib_headers} DESTINATION include/ComPWA)
+install(TARGETS DataReader
+        LIBRARY DESTINATION lib
+)
 
 # ------ TESTING ----- #
 #Testing routines are stored in separate directory
@@ -39,6 +42,9 @@ foreach(testSrc ${TEST_SRCS})
 
   #Add compile target
   add_executable( ${testName} ${testSrc})
+  #install(TARGETS ${testName}
+  #  RUNTIME DESTINATION bin
+  #)
 
   #link to Boost libraries AND your targets and dependencies
   target_link_libraries( ${testName}

--- a/DataReader/RootReader/CMakeLists.txt
+++ b/DataReader/RootReader/CMakeLists.txt
@@ -21,6 +21,9 @@ target_include_directories( RootReader
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${ROOT_INCLUDE_DIR})
 
 install (FILES ${lib_headers} DESTINATION include/ComPWA)
+install(TARGETS RootReader
+        LIBRARY DESTINATION lib
+)
 
 # ------ TESTING ----- #
 #Testing routines are stored in separate directory
@@ -34,6 +37,9 @@ foreach(testSrc ${TEST_SRCS})
 
   #Add compile target
   add_executable( ${testName} ${testSrc})
+  #install(TARGETS ${testName}
+  #  RUNTIME DESTINATION bin
+  #)
 
   #link to Boost libraries AND your targets and dependencies
   target_link_libraries( ${testName}

--- a/Estimator/ChiOneD/CMakeLists.txt
+++ b/Estimator/ChiOneD/CMakeLists.txt
@@ -17,6 +17,9 @@ target_include_directories(
 )
 
 install (FILES ${lib_headers} DESTINATION include/ComPWA)
+install(TARGETS ChiOneD
+        LIBRARY DESTINATION lib
+)
 
 # ------ TESTING ----- #
 #Testing routines are stored in separate directory
@@ -30,6 +33,9 @@ foreach(testSrc ${TEST_SRCS})
 
   #Add compile target
   add_executable( ${testName} ${testSrc})
+  #install(TARGETS ${testName}
+  #  RUNTIME DESTINATION bin
+  #)
 
   #link to Boost libraries AND your targets and dependencies
   target_link_libraries( ${testName}

--- a/Estimator/MinLogLH/CMakeLists.txt
+++ b/Estimator/MinLogLH/CMakeLists.txt
@@ -14,6 +14,9 @@ target_link_libraries(
 )
 
 install (FILES ${lib_headers} DESTINATION include/ComPWA)
+install(TARGETS MinLogLH
+        LIBRARY DESTINATION lib
+)
 
 #Run through each source
 foreach(testSrc ${TEST_SRCS})
@@ -23,6 +26,9 @@ foreach(testSrc ${TEST_SRCS})
 
   #Add compile target
   add_executable( ${testName} ${testSrc})
+  #install(TARGETS ${testName}
+  #  RUNTIME DESTINATION bin
+  #)
 
   #link to Boost libraries AND your targets and dependencies
   target_link_libraries( ${testName}

--- a/Examples/DalitzAnalysis_D0KsKK/CMakeLists.txt
+++ b/Examples/DalitzAnalysis_D0KsKK/CMakeLists.txt
@@ -22,3 +22,7 @@ target_link_libraries( DalitzFitD03K
 target_include_directories( DalitzFitD03K
   PUBLIC ${ROOT_INCLUDE_DIR} ${Boost_INCLUDE_DIR}
 )
+
+install(TARGETS DalitzFitD03K
+  RUNTIME DESTINATION bin
+)

--- a/Optimizer/Minuit2/CMakeLists.txt
+++ b/Optimizer/Minuit2/CMakeLists.txt
@@ -23,6 +23,9 @@ target_include_directories( Minuit2IF
 )
 
 install (FILES ${lib_headers} DESTINATION include/ComPWA)
+install(TARGETS Minuit2IF
+        LIBRARY DESTINATION lib
+)
 
 # ------ TESTING ----- #
 #Testing routines are stored in separate directory
@@ -36,6 +39,9 @@ foreach(testSrc ${TEST_SRCS})
 
   #Add compile target
   add_executable( ${testName} ${testSrc})
+  #install(TARGETS ${testName}
+  #  RUNTIME DESTINATION bin
+  #)
 
   #link to Boost libraries AND your targets and dependencies
   target_link_libraries( ${testName}

--- a/Physics/HelicityFormalism/CMakeLists.txt
+++ b/Physics/HelicityFormalism/CMakeLists.txt
@@ -28,6 +28,9 @@ target_include_directories( HelicityFormalism
 )
 
 install (FILES ${lib_headers} DESTINATION include/ComPWA)
+install(TARGETS HelicityFormalism
+        LIBRARY DESTINATION lib
+)
 
 # ------ TESTING ----- #
 #Testing routines are stored in separate directory
@@ -41,6 +44,9 @@ foreach(testSrc ${TEST_SRCS})
 
   #Add compile target
   add_executable( ${testName} ${testSrc})
+  #install(TARGETS ${testName}
+  #  RUNTIME DESTINATION bin
+  #)
 
   #link to Boost libraries AND your targets and dependencies
   target_link_libraries( ${testName}

--- a/Physics/qft++/CMakeLists.txt
+++ b/Physics/qft++/CMakeLists.txt
@@ -1,12 +1,29 @@
 # Create qft++ target.
 
-SET( lib_srcs TensorIndex.C Tensor.C )
-SET( lib_headers  MatrixOfTensors.h SpecialTensors.h Tensor.h Tensor_Base.h
-      TensorIndex.h Vector4.h WignerD.h OperationType.h Type.h Matrix_Base.h
-      SelectiveInclusion.h Conversion.h )
+SET( lib_srcs
+  TensorIndex.C
+  Tensor.C
+)
+SET( lib_headers
+  MatrixOfTensors.h
+  SpecialTensors.h
+  Tensor.h
+  Tensor_Base.h
+  TensorIndex.h
+  Vector4.h
+  WignerD.h
+  OperationType.h
+  Type.h
+  Matrix_Base.h
+  SelectiveInclusion.h
+  Conversion.h
+)
 
-add_library ( qft++ SHARED ${lib_srcs} ${lib_headers})
-#target_link_libraries( qft++ ${Boost_LIBRARIES} )
-#target_include_directories( HelicityFormalism PUBLIC ${Boost_INCLUDE_DIR} )
+add_library( qft++
+  SHARED ${lib_srcs} ${lib_headers}
+)
+
 install (FILES ${lib_headers} DESTINATION include/ComPWA)
-
+install(TARGETS qft++
+        LIBRARY DESTINATION lib
+)

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -34,6 +34,9 @@ target_include_directories( Tools
 
 
 install (FILES ${lib_headers} DESTINATION include/ComPWA)
+install(TARGETS Tools
+        LIBRARY DESTINATION lib
+)
 
 
 # ------ TESTING ----- #
@@ -48,6 +51,9 @@ foreach(testSrc ${TEST_SRCS})
 
   #Add compile target
   add_executable( ${testName} ${testSrc})
+  #install(TARGETS ${testName}
+  #  RUNTIME DESTINATION bin
+  #)
 
   #link to Boost libraries AND your targets and dependencies
   target_link_libraries( ${testName}


### PR DESCRIPTION
- shared libraries are now properly copied to the install path when 'make install' is called