### PR TITLE
update the usage of toySample. It is expected to do the

### DIFF
--- a/Physics/CoherentIntensity.cpp
+++ b/Physics/CoherentIntensity.cpp
@@ -129,7 +129,7 @@ CoherentIntensity::tree(std::shared_ptr<Kinematics> kin,
 
   for (auto i : Amplitudes) {
     std::shared_ptr<ComPWA::FunctionTree> resTree =
-        i->tree(kin, sample, phspSample, "");
+        i->tree(kin, sample, toySample, "");
     if (!resTree->sanityCheck())
       throw std::runtime_error("AmpSumIntensity::setupBasicTree() | "
                                "Resonance tree didn't pass sanity check!");


### PR DESCRIPTION
update the usage of toySample. It is expected to do the
normalization for amplitudes(e.g., BreitWigner and WignerD).
But actually, the phspSample is used instead of toySample.
The difference between phspSample and toySample is
that ususally phspSample will include the efficiency(i.e.,
only events passed selection) while toySample not.