### PR TITLE
fix a bug in HelicityKinematics::convert()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_install:
     - eval "${MATRIX_EVAL}"
 
 matrix:
-  #allow_failures: 
+  allow_failures: 
     #- compiler: clang
-    #- os: osx
+    - os: osx
 
   include:
     - os: osx

--- a/Physics/HelicityFormalism/HelicityKinematics.cpp
+++ b/Physics/HelicityFormalism/HelicityKinematics.cpp
@@ -352,6 +352,8 @@ void HelicityKinematics::convert(const Event &event, DataPoint &point,
                      " Point beypond phase space boundaries!");
   }
 
+  point.setWeight(event.weight());
+  point.setEfficiency(event.efficiency());
   point.values().push_back(mSq);
   point.values().push_back(cosTheta);
   point.values().push_back(phi);


### PR DESCRIPTION
in old version, HeliciytKinematic::convert() losted the weight of event when
 convert an Event to a DataPoint.
The losted weights will change the Likelihood when the weight of
data is not 1, e.g., one part of data is real data with weight = 1,
the second part of data is for background, which will has negative
weight.