### PR TITLE
Fix travisCI tests on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,9 @@ matrix:
         - pip install --upgrade pip setuptools wheel
           # using a virtualenv for the requirements installation is important
           # otherwise the deps are screwed up and matplotlib compiles its own numpy!
-        # root installation via brew
-        - brew install root
+        # ROOT installation via brew. ROOT is compiled so we have to add `travis_wait` to
+        # ensure that the build is not canceled since no output is received.
+        - travis_wait brew install root
         #- wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz
         #- tar xpvfz root_*.tar.gz > /dev/null 2>&1
         #- source ./root/bin/thisroot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -249,7 +249,7 @@ script:
          mkdir $BASEPATH/build;
          cd $BASEPATH/build;
          cmake -DPYBIND11_PYTHON_VERSION=3.4 $BASEPATH/ComPWA/;
-         make -j2 VERBOSE=1;
+         make -j2;
          make test;
       fi
       

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,7 @@ matrix:
         #
         # GCC is installed as a dependency of root and overwrites pre installed
         # files in /usr/local
-        - if brew install gcc; then
-             brew link --overwrite gcc;     
+        - brew install gcc || brew link --overwrite gcc
         # ROOT is compiled (default installation path of brew is changed. So no bottles can be used.)
         # We have to add `travis_wait` to ensure that the build is not canceled since no output 
         # is received.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
         - OMP_NUM_THREADS: 1
         - LANG: en_US.UTF-8
         - BASEPATH: $HOME/build/ComPWA
+        - DYLD_FALLBACK_LIBRARY_PATH: /Users/travis/build/ComPWA/ComPWA/root/lib
           # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
           # via the "travis encrypt" command using the project repo's public key
         - secure: "I1LwO65P4q89f31HYnFlrlJ9yHyJ/QIAOXR5CtPfMo5FnestBtlQg6fX3p1vLNi5XdYXP4QpP51FFGJ5suz1aigC45JRaMzO98WQmMvIqYufrhkYej6lNevL0z/tHeI0aURH7N1SfSZaLwkepErssOsdjJAqP538ldA3Zz9g2gM="

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,28 +63,23 @@ matrix:
         - pip install --upgrade pip setuptools wheel
         # Install requirements for ExpertSystem
         - pip install -r Physics/ExpertSystem/requirements.txt
-        - ls /usr/local/bin
-        - brew --prefix
-        - ls $(brew --prefix)/bin
-        - brew info --json=v1 root
         #
         # Installation of ROOT
         #
         # GCC is installed as a dependency of root and overwrites pre installed
         # files in /usr/local
         - brew install gcc || brew link --overwrite gcc
+        - which gcc
+        - gcc --version
         # ROOT is compiled (default installation path of brew is changed. So no bottles can be used.)
         # We have to add `travis_wait` to ensure that the build is not canceled since no output 
         # is received.
-        #- travis_wait 40 brew install root
-        - travis_wait 40 brew install --force-bottle root
+        - travis_wait 40 brew install root
+        #- travis_wait 40 brew install --force-bottle root
+        # Install ROOT from precompiled binaries
         #- wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz
         #- tar xpvfz root_*.tar.gz > /dev/null 2>&1
         #- source ./root/bin/thisroot.sh
-        # Pre-compiled binaries does not have the rpath properly set. So we set the 
-        # DYLD_FALLBACK_LIBRARY_PATH here.
-        #- DYLD_FALLBACK_LIBRARY_PATH=$LIBPATH; export DYLD_FALLBACK_LIBRARY_PATH
-        - env
 
     - os: linux
       dist: trusty
@@ -268,7 +263,7 @@ script:
          cd $BASEPATH/build;
          cmake $BASEPATH/ComPWA/;
          make -j2;
-         make test;
+         if make test;
       fi
       
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
         - OMP_NUM_THREADS: 1
         - LANG: en_US.UTF-8
         - BASEPATH: $HOME/build/ComPWA
-        - DYLD_FALLBACK_LIBRARY_PATH: /Users/travis/build/ComPWA/ComPWA/root/lib
           # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
           # via the "travis encrypt" command using the project repo's public key
         - secure: "I1LwO65P4q89f31HYnFlrlJ9yHyJ/QIAOXR5CtPfMo5FnestBtlQg6fX3p1vLNi5XdYXP4QpP51FFGJ5suz1aigC45JRaMzO98WQmMvIqYufrhkYej6lNevL0z/tHeI0aURH7N1SfSZaLwkepErssOsdjJAqP538ldA3Zz9g2gM="
@@ -40,36 +39,51 @@ matrix:
       osx_image: xcode9.3
       env:
         - TASK="clang ROOT v6.12"
-      #allow_failures: true
       before_script:
-          # We have to check first if a package is installed, otherwise an error
-          # is thrown.
+        # We have to check first if a package is installed, otherwise an error
+        # is thrown.
         - if brew ls --versions boost > /dev/null; then 
             echo "Boost installed:\ `brew ls --versions boost`";
           else brew install boost; fi
         - if brew ls --versions gsl > /dev/null; then 
             echo 'GSL installed:\ `brew ls --versions gsl`';
           else brew install gsl; fi
+        #
+        # Python
+        #
+        # Update 2.7 -> 3.7
         - brew upgrade python
+        # Add the brew python binary path to ensure python3 will be used
         - export PATH=/usr/local/opt/python/libexec/bin:$PATH
-          # add the brew python binary path to ensure python3 will be used
+        # Using a virtualenv for the requirements installation is important
+        # otherwise the deps are screwed up and matplotlib compiles its own numpy!
         - pip3 install --user -U virtualenv
         - virtualenv python-venv -p python3
         - source python-venv/bin/activate
         - pip install --upgrade pip setuptools wheel
-          # using a virtualenv for the requirements installation is important
-          # otherwise the deps are screwed up and matplotlib compiles its own numpy!
-        # ROOT installation via brew. ROOT is compiled so we have to add `travis_wait` to
-        # ensure that the build is not canceled since no output is received.
-        - travis_wait 30 brew install root
+        # Install requirements for ExpertSystem
+        - pip install -r Physics/ExpertSystem/requirements.txt
+        - ls /usr/local/bin
+        - brew --prefix
+        - ls $(brew --prefix)/bin
+        - brew info --json=v1 root
+        #
+        # Installation of ROOT
+        #
+        # GCC is installed as a dependency of root and overwrites pre installed
+        # files in /usr/local
+        - brew link --overwrite gcc
+        # ROOT is compiled (default installation path of brew is changed. So no bottles can be used.)
+        # We have to add `travis_wait` to ensure that the build is not canceled since no output 
+        # is received.
+        - travis_wait 40 brew install root
+        #- travis_wait 30 brew install --force-bottle root
         #- wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz
         #- tar xpvfz root_*.tar.gz > /dev/null 2>&1
         #- source ./root/bin/thisroot.sh
         # Pre-compiled binaries does not have the rpath properly set. So we set the 
         # DYLD_FALLBACK_LIBRARY_PATH here.
         #- DYLD_FALLBACK_LIBRARY_PATH=$LIBPATH; export DYLD_FALLBACK_LIBRARY_PATH
-        # Install requirements for ExpertSystem
-        - pip install -r Physics/ExpertSystem/requirements.txt
         - env
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,12 +72,13 @@ matrix:
         #
         # GCC is installed as a dependency of root and overwrites pre installed
         # files in /usr/local
+        - brew install gcc
         - brew link --overwrite gcc
         # ROOT is compiled (default installation path of brew is changed. So no bottles can be used.)
         # We have to add `travis_wait` to ensure that the build is not canceled since no output 
         # is received.
-        - travis_wait 40 brew install root
-        #- travis_wait 30 brew install --force-bottle root
+        #- travis_wait 40 brew install root
+        - travis_wait 40 brew install --force-bottle root
         #- wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz
         #- tar xpvfz root_*.tar.gz > /dev/null 2>&1
         #- source ./root/bin/thisroot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ matrix:
         - DYLD_FALLBACK_LIBRARY_PATH=$LIBPATH; export DYLD_FALLBACK_LIBRARY_PATH
         # Install requirements for ExpertSystem
         - pip install -r Physics/ExpertSystem/requirements.txt
+        - env
 
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -258,7 +258,7 @@ script:
       
 after_failure:
     - if [ -f ./Testing/Temporary/LastTest.log ]; then
-        env
+        env;
         cat ./Testing/Temporary/LastTest.log;
         sleep 30;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ matrix:
         # ROOT is compiled (default installation path of brew is changed. So no bottles can be used.)
         # We have to add `travis_wait` to ensure that the build is not canceled since no output 
         # is received.
-        - travis_wait 40 brew install root
+        - travis_wait 60 brew install root
         #- travis_wait 40 brew install --force-bottle root
         # Install ROOT from precompiled binaries
         #- wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -263,7 +263,7 @@ script:
          cd $BASEPATH/build;
          cmake $BASEPATH/ComPWA/;
          make -j2;
-         if make test;
+         make test;
       fi
       
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,9 @@ matrix:
         - wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz
         - tar xpvfz root_*.tar.gz > /dev/null 2>&1
         - source ./root/bin/thisroot.sh
+        # Pre-compiled binaries does not have the rpath properly set. So we set the 
+        # DYLD_FALLBACK_LIBRARY_PATH here.
+        - export DYLD_FALLBACK_LIBRARY_PATH=$LIBPATH
         - pip install -r Physics/ExpertSystem/requirements.txt
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,8 @@ matrix:
         - source ./root/bin/thisroot.sh
         # Pre-compiled binaries does not have the rpath properly set. So we set the 
         # DYLD_FALLBACK_LIBRARY_PATH here.
-        - export DYLD_FALLBACK_LIBRARY_PATH=$LIBPATH
-        - echo $DYLD_FALLBACK_LIBRARY_PATH
-        - export DYLD_LIBRARY_PATH=$LIBPATH
-        - echo $DYLD_LIBRARY_PATH
+        - DYLD_FALLBACK_LIBRARY_PATH=$LIBPATH; export DYLD_FALLBACK_LIBRARY_PATH
+        # Install requirements for ExpertSystem
         - pip install -r Physics/ExpertSystem/requirements.txt
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -256,4 +256,5 @@ script:
 after_failure:
     - if [ -f ./Testing/Temporary/LastTest.log ]; then
         cat ./Testing/Temporary/LastTest.log;
+        sleep 30;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -258,6 +258,7 @@ script:
       
 after_failure:
     - if [ -f ./Testing/Temporary/LastTest.log ]; then
+        env
         cat ./Testing/Temporary/LastTest.log;
         sleep 30;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,9 @@ matrix:
         # Pre-compiled binaries does not have the rpath properly set. So we set the 
         # DYLD_FALLBACK_LIBRARY_PATH here.
         - export DYLD_FALLBACK_LIBRARY_PATH=$LIBPATH
+        - echo $DYLD_FALLBACK_LIBRARY_PATH
+        - export DYLD_LIBRARY_PATH=$LIBPATH
+        - echo $DYLD_LIBRARY_PATH
         - pip install -r Physics/ExpertSystem/requirements.txt
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,14 @@ matrix:
         - pip install --upgrade pip setuptools wheel
           # using a virtualenv for the requirements installation is important
           # otherwise the deps are screwed up and matplotlib compiles its own numpy!
-        # root installation via brew makes some troubles atm
-        #- brew install root
-        - wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz
-        - tar xpvfz root_*.tar.gz > /dev/null 2>&1
-        - source ./root/bin/thisroot.sh
+        # root installation via brew
+        - brew install root
+        #- wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz
+        #- tar xpvfz root_*.tar.gz > /dev/null 2>&1
+        #- source ./root/bin/thisroot.sh
         # Pre-compiled binaries does not have the rpath properly set. So we set the 
         # DYLD_FALLBACK_LIBRARY_PATH here.
-        - DYLD_FALLBACK_LIBRARY_PATH=$LIBPATH; export DYLD_FALLBACK_LIBRARY_PATH
+        #- DYLD_FALLBACK_LIBRARY_PATH=$LIBPATH; export DYLD_FALLBACK_LIBRARY_PATH
         # Install requirements for ExpertSystem
         - pip install -r Physics/ExpertSystem/requirements.txt
         - env
@@ -251,7 +251,7 @@ script:
     - if [[ "$COVERITY_SCAN_BRANCH" != "1" ]]; then
          mkdir $BASEPATH/build;
          cd $BASEPATH/build;
-         cmake -DPYBIND11_PYTHON_VERSION=3.4 $BASEPATH/ComPWA/;
+         cmake $BASEPATH/ComPWA/;
          make -j2;
          make test;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_install:
     - eval "${MATRIX_EVAL}"
 
 matrix:
-  #allow_failures: 
+  allow_failures: 
     #- compiler: clang
-    #- os: osx
+    - os: osx
 
   include:
     - os: osx
@@ -68,17 +68,17 @@ matrix:
         #
         # GCC is installed as a dependency of root and overwrites pre installed
         # files in /usr/local
-        - brew install gcc || brew link --overwrite gcc
+        #- brew install gcc || brew link --overwrite gcc
         # ROOT is compiled (default installation path of brew is changed. So no bottles can be used.)
         # We have to add `travis_wait` to ensure that the build is not canceled since no output 
         # is received. The total maximum walltime is 50min on TravisCI for public repos.
         #- travis_wait 40 brew install root
-        - brew install --force-bottle root
-        - source /usr/local/bin/thisroot.sh
+        #- brew install --force-bottle root
+        #- source /usr/local/bin/thisroot.sh
         # Install ROOT from precompiled binaries
-        #- wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz
-        #- tar xpvfz root_*.tar.gz > /dev/null 2>&1
-        #- source ./root/bin/thisroot.sh
+        - wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz
+        - tar xpvfz root_*.tar.gz > /dev/null 2>&1
+        - source ./root/bin/thisroot.sh
 
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ before_install:
     - eval "${MATRIX_EVAL}"
 
 matrix:
-  allow_failures: 
+  #allow_failures: 
     #- compiler: clang
-    - os: osx
+    #- os: osx
 
   include:
     - os: osx
@@ -61,7 +61,7 @@ matrix:
           # otherwise the deps are screwed up and matplotlib compiles its own numpy!
         # ROOT installation via brew. ROOT is compiled so we have to add `travis_wait` to
         # ensure that the build is not canceled since no output is received.
-        - travis_wait brew install root
+        - travis_wait 30 brew install root
         #- wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz
         #- tar xpvfz root_*.tar.gz > /dev/null 2>&1
         #- source ./root/bin/thisroot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,13 +69,12 @@ matrix:
         # GCC is installed as a dependency of root and overwrites pre installed
         # files in /usr/local
         - brew install gcc || brew link --overwrite gcc
-        - which gcc
-        - gcc --version
         # ROOT is compiled (default installation path of brew is changed. So no bottles can be used.)
         # We have to add `travis_wait` to ensure that the build is not canceled since no output 
-        # is received.
-        - travis_wait 60 brew install root
-        #- travis_wait 40 brew install --force-bottle root
+        # is received. The total maximum walltime is 50min on TravisCI for public repos.
+        #- travis_wait 40 brew install root
+        - brew install --force-bottle root
+        - source /usr/local/bin/thisroot.sh
         # Install ROOT from precompiled binaries
         #- wget https://root.cern.ch/download/root_v6.12.06.macosx64-10.13-clang90.tar.gz
         #- tar xpvfz root_*.tar.gz > /dev/null 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ matrix:
         #
         # GCC is installed as a dependency of root and overwrites pre installed
         # files in /usr/local
-        - brew install gcc
-        - brew link --overwrite gcc
+        - if brew install gcc; then
+             brew link --overwrite gcc;     
         # ROOT is compiled (default installation path of brew is changed. So no bottles can be used.)
         # We have to add `travis_wait` to ensure that the build is not canceled since no output 
         # is received.


### PR DESCRIPTION
Pre-compiled ROOT binaries does not have the rpath properly set.