### PR TITLE
EvtGen module bugfix

### DIFF
--- a/Core/AmpIntensity.hpp
+++ b/Core/AmpIntensity.hpp
@@ -10,16 +10,16 @@
 #ifndef AMPINTENSITY_HPP_
 #define AMPINTENSITY_HPP_
 
-#include <vector>
-#include <memory>
 #include <math.h>
+#include <memory>
+#include <vector>
 
-#include "Data/Data.hpp"
-#include "Core/ParameterList.hpp"
-#include "Core/FunctionTree.hpp"
 #include "Core/DataPoint.hpp"
 #include "Core/Efficiency.hpp"
+#include "Core/FunctionTree.hpp"
 #include "Core/Generator.hpp"
+#include "Core/ParameterList.hpp"
+#include "Data/Data.hpp"
 
 namespace ComPWA {
 
@@ -85,7 +85,7 @@ public:
   setPhspSample(std::shared_ptr<std::vector<ComPWA::DataPoint>> phspSample,
                 std::shared_ptr<std::vector<ComPWA::DataPoint>> toySample) = 0;
 
-  virtual std::shared_ptr<AmpIntensity> component(std::string name) = 0;
+  virtual std::shared_ptr<AmpIntensity> component(const std::string &name) = 0;
 
   //========== FUNCTIONTREE =============
 
@@ -120,5 +120,5 @@ inline std::vector<std::string> splitString(std::string str) {
   return result;
 }
 
-} // ns::ComPWA
+} // namespace ComPWA
 #endif

--- a/Physics/CoherentIntensity.cpp
+++ b/Physics/CoherentIntensity.cpp
@@ -2,9 +2,9 @@
 // This file is part of the ComPWA framework, check
 // https://github.com/ComPWA/ComPWA/license.txt for details.
 
-#include <numeric>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
+#include <numeric>
 
 #include "Core/Efficiency.hpp"
 #include "Physics/CoherentIntensity.hpp"
@@ -15,8 +15,9 @@ using namespace ComPWA::Physics;
 using namespace ComPWA::Physics::HelicityFormalism;
 
 CoherentIntensity::CoherentIntensity(std::shared_ptr<ComPWA::PartList> partL,
-                  std::shared_ptr<ComPWA::Kinematics> kin,
-                  const boost::property_tree::ptree &pt) : PhspVolume(1.0) {
+                                     std::shared_ptr<ComPWA::Kinematics> kin,
+                                     const boost::property_tree::ptree &pt)
+    : PhspVolume(1.0) {
   load(partL, kin, pt);
 }
 
@@ -37,9 +38,9 @@ void CoherentIntensity::load(std::shared_ptr<PartList> partL,
                     "not containt a configuration for an "
                     "CoherentIntensity!");
   Name = (pt.get<std::string>("<xmlattr>.Name"));
-  Strength = std::make_shared<ComPWA::FitParameter>("Strength_"+Name, 1.0);
+  Strength = std::make_shared<ComPWA::FitParameter>("Strength_" + Name, 1.0);
   setPhspVolume(kin->phspVolume());
-  
+
   for (const auto &v : pt.get_child("")) {
     // Strength parameter
     if (v.first == "Parameter" &&
@@ -64,12 +65,12 @@ boost::property_tree::ptree CoherentIntensity::save() const {
 
   for (auto i : Amplitudes)
     pt.add_child("Amplitude", i->save());
-  
+
   return pt;
 }
 
 std::shared_ptr<ComPWA::AmpIntensity>
-CoherentIntensity::component(std::string name) {
+CoherentIntensity::component(const std::string &name) {
 
   // The whole object?
   if (name == Name) {
@@ -120,12 +121,10 @@ CoherentIntensity::tree(std::shared_ptr<Kinematics> kin,
 
   tr->createLeaf("Strength", Strength,
                  "CoherentIntensity(" + name() + ")" + suffix);
-  tr->createNode("SumSquared",
-                 std::make_shared<AbsSquare>(ParType::MDOUBLE),
+  tr->createNode("SumSquared", std::make_shared<AbsSquare>(ParType::MDOUBLE),
                  "CoherentIntensity(" + name() + ")" + suffix);
   tr->createNode("SumOfAmplitudes", MComplex("", n),
-                 std::make_shared<AddAll>(ParType::MCOMPLEX),
-                 "SumSquared");
+                 std::make_shared<AddAll>(ParType::MCOMPLEX), "SumSquared");
 
   for (auto i : Amplitudes) {
     std::shared_ptr<ComPWA::FunctionTree> resTree =

--- a/Physics/EvtGen/CMakeLists.txt
+++ b/Physics/EvtGen/CMakeLists.txt
@@ -3,6 +3,9 @@
 file(GLOB lib_srcs "*.cpp")
 file(GLOB lib_headers "*.hh")
 
+set(lib_srcs ${lib_srcs} ../SubSystem.cpp)
+set(lib_headers ${lib_headers} ../SubSystem.hpp)
+
 add_library(EvtGenIF
   SHARED ${lib_srcs} ${lib_headers}
 )

--- a/Physics/EvtGen/ComPWAEvtGenIF.cpp
+++ b/Physics/EvtGen/ComPWAEvtGenIF.cpp
@@ -9,8 +9,8 @@
 using namespace ComPWA::Physics::EvtGenIF;
 using ComPWA::Physics::SubSystem;
 
-void EvtGenIF::addResonance(std::string name, double m0, double g0, double spin,
-                            SubSystem subsys) {
+void EvtGenIF::addResonance(const std::string &name, double m0, double g0,
+                            double spin, const SubSystem &subsys) {
   // LOG(debug) << "EvtGenIF::addResonance starts. Name: " << name << " mass: "
   // << m0 << " width: " << g0 << " spin: " << spin;
   EvtCyclic3::Pair pairAng;
@@ -59,7 +59,7 @@ void EvtGenIF::addResonance(std::string name, double m0, double g0, double spin,
   // LOG(debug) << "EvtGenIF::addResonance finishes";
 }
 
-void EvtGenIF::addHeliResonance(boost::property_tree::ptree pt,
+void EvtGenIF::addHeliResonance(const boost::property_tree::ptree &pt,
                                 std::shared_ptr<PartList> partL) {
   // LOG(debug) << "EvtGenIF::addHeliResonance starts";
 
@@ -161,7 +161,7 @@ void EvtGenIF::addHeliResonance(boost::property_tree::ptree pt,
   }
 }
 
-void EvtGenIF::addResonances(boost::property_tree::ptree pt,
+void EvtGenIF::addResonances(const boost::property_tree::ptree &pt,
                              std::shared_ptr<DalitzKinematics> kin,
                              std::shared_ptr<PartList> partL) {
   if (pt.get<std::string>("<xmlattr>.Class") != "Incoherent")
@@ -294,8 +294,8 @@ boost::property_tree::ptree EvtGenIF::save() const {
   return pt;
 }
 
-std::shared_ptr<ComPWA::AmpIntensity> EvtGenIF::component(std::string name) {
-
+std::shared_ptr<ComPWA::AmpIntensity>
+EvtGenIF::component(const std::string &name) {
   return nullptr;
 }
 

--- a/Physics/EvtGen/ComPWAEvtGenIF.hpp
+++ b/Physics/EvtGen/ComPWAEvtGenIF.hpp
@@ -36,18 +36,19 @@ public:
 
   virtual boost::property_tree::ptree save() const;
 
-  virtual std::shared_ptr<AmpIntensity> component(std::string name);
+  virtual std::shared_ptr<AmpIntensity> component(const std::string &name);
 
   /// Add EvtGen Dalitz Resonance
-  virtual void addResonance(std::string name, double m0, double g0, double spin,
-                            ComPWA::Physics::SubSystem subsys);
+  virtual void addResonance(const std::string &name, double m0, double g0,
+                            double spin,
+                            const ComPWA::Physics::SubSystem &subsys);
 
   /// Add EvtGen Dalitz Resonance
-  virtual void addHeliResonance(boost::property_tree::ptree pt,
+  virtual void addHeliResonance(const boost::property_tree::ptree &pt,
                                 std::shared_ptr<PartList> partL);
 
   /// Add EvtGen Dalitz Resonances from XML model
-  virtual void addResonances(boost::property_tree::ptree pt,
+  virtual void addResonances(const boost::property_tree::ptree &pt,
                              std::shared_ptr<DalitzKinematics> kin,
                              std::shared_ptr<PartList> partL);
 

--- a/Physics/IncoherentIntensity.cpp
+++ b/Physics/IncoherentIntensity.cpp
@@ -3,8 +3,8 @@
 // https://github.com/ComPWA/ComPWA/license.txt for details.
 //
 
-#include <numeric>
 #include "Physics/IncoherentIntensity.hpp"
+#include <numeric>
 
 using namespace ComPWA::Physics;
 
@@ -89,19 +89,20 @@ double IncoherentIntensity::intensity(const ComPWA::DataPoint &point) const {
 }
 
 std::shared_ptr<ComPWA::AmpIntensity>
-IncoherentIntensity::component(std::string name) {
+IncoherentIntensity::component(const std::string &name) {
 
   // The whole object?
   if (name == Name) {
-//    LOG(ERROR) << "IncoherentIntensity::GetComponent() | You're requesting the "
-//                  "full object! So just copy it!";
-//    return std::shared_ptr<AmpIntensity>();
+    //    LOG(ERROR) << "IncoherentIntensity::GetComponent() | You're requesting
+    //    the "
+    //                  "full object! So just copy it!";
+    //    return std::shared_ptr<AmpIntensity>();
     return shared_from_this();
   }
-  
+
   // Do we want to have a combination of CoherentIntensities?
   std::vector<std::string> names = splitString(name);
-  
+
   // In case the requested is a direct component we return a CoherentIntensity
   // object
   if (names.size() == 1) {

--- a/Physics/IncoherentIntensity.hpp
+++ b/Physics/IncoherentIntensity.hpp
@@ -12,7 +12,8 @@
 namespace ComPWA {
 namespace Physics {
 
-class IncoherentIntensity : public ComPWA::AmpIntensity,
+class IncoherentIntensity
+    : public ComPWA::AmpIntensity,
       public std::enable_shared_from_this<IncoherentIntensity> {
 
 public:
@@ -30,7 +31,7 @@ public:
   }
 
   void load(std::shared_ptr<PartList> partL, std::shared_ptr<Kinematics> kin,
-          const boost::property_tree::ptree &pt);
+            const boost::property_tree::ptree &pt);
 
   virtual boost::property_tree::ptree save() const;
 
@@ -53,8 +54,8 @@ public:
 
   virtual void reset() {
     Intensities.clear();
-//    NormalizationValues.clear();
-//    Parameters.clear();
+    //    NormalizationValues.clear();
+    //    Parameters.clear();
     return;
   }
 
@@ -68,7 +69,7 @@ public:
       i->parametersFast(list);
     }
   }
-  
+
   /// Update parameters in AmpIntensity to the values given in \p list
   virtual void updateParameters(const ParameterList &list);
 
@@ -90,8 +91,7 @@ public:
 
   virtual void setPhspVolume(double vol) { PhspVolume = vol; };
 
-  virtual std::shared_ptr<AmpIntensity> component(std::string name);
-
+  virtual std::shared_ptr<AmpIntensity> component(const std::string &name);
 
   /// Check of tree is available
   virtual bool hasTree() const { return true; }
@@ -99,9 +99,9 @@ public:
   /// Get FunctionTree
   virtual std::shared_ptr<ComPWA::FunctionTree>
   tree(std::shared_ptr<Kinematics> kin, const ComPWA::ParameterList &sample,
-          const ComPWA::ParameterList &phspSample,
-          const ComPWA::ParameterList &toySample, unsigned int nEvtVar,
-          std::string suffix = "");
+       const ComPWA::ParameterList &phspSample,
+       const ComPWA::ParameterList &toySample, unsigned int nEvtVar,
+       std::string suffix = "");
 
 protected:
   /// Phase space sample to calculate the normalization and maximum value.


### PR DESCRIPTION
- Fixed bug in the EvtGen physics module. SubSystems were not used  
  correctly (and older compilers are not able to optimize it
  automatically).
- Improved const correctness slightly