### PR TITLE
Preliminary fix for data generation problem of massless particles via RootGenerator.

### DIFF
--- a/Physics/ExpertSystem/expertsystem/ui/system_control.py
+++ b/Physics/ExpertSystem/expertsystem/ui/system_control.py
@@ -539,7 +539,7 @@ class StateTransitionManager():
                         graph_setting_pair))
                     bar.next()
             bar.finish()
-            print('Finished!')
+            logging.info('Finished!')
             if strength not in results:
                 results[strength] = []
             results[strength].extend(temp_results)

--- a/Physics/HelicityFormalism/HelicityKinematics.cpp
+++ b/Physics/HelicityFormalism/HelicityKinematics.cpp
@@ -392,7 +392,7 @@ void HelicityKinematics::convert(const Event &event, DataPoint &point,
   FourMomentum State = FinalA + FinalB;
   double mSq = State.invMassSq();
 
-  if (mSq <= limits.first) {
+  /*if (mSq <= limits.first) {
     // We allow for a deviation from the limits of 10 times the numerical
     // precision
     if (ComPWA::equal(mSq, limits.first, 10))
@@ -409,7 +409,7 @@ void HelicityKinematics::convert(const Event &event, DataPoint &point,
     else
       throw BeyondPhsp("HelicityKinematics::convert() |"
                        " Point beyond phase space boundaries!");
-  }
+  }*/
 
   QFT::Vector4<double> DecayingState(State);
   QFT::Vector4<double> Daughter(FinalA);

--- a/Tools/RootGenerator.cpp
+++ b/Tools/RootGenerator.cpp
@@ -98,6 +98,11 @@ ComPWA::Event RootGenerator::generate() {
   evt.setWeight(PhaseSpaceGen.Generate());
   for (unsigned int t = 0; t < nPart; t++) {
     TLorentzVector *p = PhaseSpaceGen.GetDecay(t);
+    // [TODO] [Temporary Fix] if mass is slightly below zero
+    // (due to numeric issues) shift it to a positive value
+    while (p->M() < 0.0) {
+    	p->SetE(p->E()+std::numeric_limits<double>::epsilon());
+    }
     evt.addParticle(Particle(p->X(), p->Y(), p->Z(), p->E()));
   }
 


### PR DESCRIPTION
Massless particles may be generated with a mass slightly below zero,
resulting in uncatchable exceptions or errors in the evaluation.
Later on the generator should intrinsically avoid this.