### PR TITLE
Added final solution filtering in the expertsystem

### DIFF
--- a/pycompwa/pycompwa/expertsystem/state/particle.py
+++ b/pycompwa/pycompwa/expertsystem/state/particle.py
@@ -335,6 +335,12 @@ def get_interaction_property(interaction_properties, qn_name, converter=None):
     else:
         if qn_name in QNDefaultValues:
             property_value = QNDefaultValues[qn_name]
+        else:
+            logging.warning("Requested quantum number " + str(qn_name)
+                            + " was not found in the interaction properties."
+                            + "\nAlso no default setting for this quantum "
+                            + "number is available. Perhaps you are using the"
+                            + " wrong formalism?")
     return property_value
 
 


### PR DESCRIPTION
- The final solutions found by the expert system can now be filtered
  based on a list of functions. The user can user customized functions
  using lambdas. A predefined closure function is available for
  requiring certain values for interaction node properties.
  E.g: only select solutions, where L=1 for a specific particle decay
  Also added extensive docstrings for this functionality.
- Added unit tests for the solution graph filtering
- Small refactoring in the system_control python module