### PR TITLE
Improvements for event weight and logging bugfixes

### DIFF
--- a/Core/Logging.cpp
+++ b/Core/Logging.cpp
@@ -12,22 +12,22 @@ INITIALIZE_EASYLOGGINGPP
 namespace ComPWA {
 
 Logging::Logging(std::string level, std::string filename) {
-
+  el::Configurations DefaultConfig;
+  // initialize with default values
+  DefaultConfig.setToDefault();
   if (filename.empty()) {
-    el::Configurations DefaultConfig;
-    DefaultConfig.setToDefault();
+    DefaultConfig.setGlobally(el::ConfigurationType::ToFile, "0");
+    LOG(INFO) << "Logging to file disabled!";
+
+  } else {
     DefaultConfig.setGlobally(el::ConfigurationType::Filename, filename);
     DefaultConfig.setGlobally(el::ConfigurationType::Format,
                               "%datetime [%level] %msg");
     DefaultConfig.setGlobally(el::ConfigurationType::ToFile, "1");
-    DefaultConfig.setGlobally(el::ConfigurationType::ToStandardOutput, "1");
-
-    // default logger uses default configurations
-    el::Loggers::reconfigureLogger("default", DefaultConfig);
     LOG(INFO) << "Log file: " << filename;
-  } else {
-    LOG(INFO) << "Logging to file disabled!";
   }
+  // reconfigure the default logger
+  el::Loggers::reconfigureLogger("default", DefaultConfig);
 
   setLogLevel(level);
 

--- a/Core/Logging.hpp
+++ b/Core/Logging.hpp
@@ -18,7 +18,7 @@ namespace ComPWA {
 
 class Logging {
 public:
-  Logging(std::string level = "DEBUG", std::string filename = "");
+  Logging(std::string level = "INFO", std::string filename = "");
 
   void setLogLevel(std::string level);
 };

--- a/Data/DataSet.cpp
+++ b/Data/DataSet.cpp
@@ -3,6 +3,7 @@
 // https://github.com/ComPWA/ComPWA/license.txt for details.
 
 #include "DataSet.hpp"
+#include "Core/Intensity.hpp"
 #include "Core/Kinematics.hpp"
 
 namespace ComPWA {
@@ -36,6 +37,15 @@ void DataSet::reduceToPhaseSpace(
   LOG(INFO) << "DataSet::reduceToPhsp(): " << EventList.size() << " from "
             << EventList.size() << "(" << (1.0 - PreviousSize / NewSize) * 100
             << "%) were removed.";
+}
+
+void DataSet::addIntensityWeights(
+    std::shared_ptr<ComPWA::Intensity> Intensity,
+    std::shared_ptr<ComPWA::Kinematics> Kinematics) {
+  for (auto &evt : EventList) {
+    double Weight = Intensity->evaluate(Kinematics->convert(evt));
+    evt.Weight *= Weight;
+  }
 }
 
 void DataSet::convertEventsToDataPoints(

--- a/Data/DataSet.hpp
+++ b/Data/DataSet.hpp
@@ -13,6 +13,7 @@
 
 namespace ComPWA {
 class Kinematics;
+class Intensity;
 namespace Data {
 
 class DataSet {
@@ -22,6 +23,8 @@ public:
   DataSet(const std::vector<DataPoint> &DataPoints);
 
   void reduceToPhaseSpace(std::shared_ptr<ComPWA::Kinematics> Kinematics);
+  void addIntensityWeights(std::shared_ptr<ComPWA::Intensity> Intensity,
+                           std::shared_ptr<ComPWA::Kinematics> Kinematics);
 
   void convertEventsToDataPoints(std::shared_ptr<Kinematics> Kinematics);
   void convertEventsToParameterList(std::shared_ptr<Kinematics> Kinematics);

--- a/pycompwa/PythonInterface/PyComPWA.cpp
+++ b/pycompwa/PythonInterface/PyComPWA.cpp
@@ -47,10 +47,13 @@ PYBIND11_MODULE(ui, m) {
   m.doc() = "pycompwa module\n"
             "---------------\n";
   // ------- Logging
-
+  // reinitialize the logger with level INFO
+  ComPWA::Logging("INFO");
   py::class_<ComPWA::Logging, std::shared_ptr<ComPWA::Logging>>(m, "Logging")
       .def(py::init<std::string, std::string>(), "Initialize logging system",
-           py::arg("output"), py::arg("log_level"));
+           py::arg("log_level"), py::arg("filename"))
+      .def(py::init<std::string>(), "Initialize logging system",
+           py::arg("log_level"));
   m.def("log", [](std::string msg) { LOG(INFO) << msg; },
         "Write string to logging system.");
 
@@ -191,7 +194,10 @@ PYBIND11_MODULE(ui, m) {
       .def("convert_events_to_parameterlist",
            &ComPWA::Data::DataSet::convertEventsToParameterList,
            "Internally convert the events to a horizontal data structure.",
-           py::arg("kinematics"));
+           py::arg("kinematics"))
+      .def("add_intensity_weights", &ComPWA::Data::DataSet::addIntensityWeights,
+           "Add the intensity values as weights to this data sample.",
+           py::arg("intensity"), py::arg("kinematics"));
 
   // ------- Particles
 
@@ -222,7 +228,8 @@ PYBIND11_MODULE(ui, m) {
         (void (*)(std::shared_ptr<ComPWA::PartList>, std::string)) &
             ComPWA::ReadParticles);
 
-  m.def("default_particles", []() { return ComPWA::Physics::defaultParticleList; },
+  m.def("default_particles",
+        []() { return ComPWA::Physics::defaultParticleList; },
         "Get a list of predefined particles.");
 
   // ------- Kinematics


### PR DESCRIPTION
- Added feature to add intensity weights to an existing data sample
  (Fixes #183). This is also available in the python UI.
- Bugfix in logging, where logging to file was turned on when no file is
  specified.
- Changed default logging level to INFO