### PR TITLE
Fixed commit link for submodule ThirdParty/ttb + VScode additions to …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ python-venv/
 *Config.cmake
 *ConfigVersion.cmake
 *ipynb_checkpoints
+.vscode/
+*.code-workspace

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
     # - os: osx
   include:
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode10.2
       env:
         - TASK="clang ROOT v6.12"
         - ROOTBIN="v6.12.06.macosx64-10.13-clang90"


### PR DESCRIPTION
Submodule `ThirdParty/tbb` was referring to non-existing SHA `b066defc0229a1e92d7a200eb3fe0f7e35945d95`, so I pulled the [latest version of `tbb`](https://github.com/wjakob/tbb/tree/344fa84f34089681732a54f5def93a30a3056ab9) and updated the submodule. Also added two exclusions to [`.gitignore`](./.gitignore).