### PR TITLE
Remove shallow cloneing of submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "ThirdParty/parallelstl"]
 	path = ThirdParty/parallelstl
 	url = https://github.com/intel/parallelstl.git
-	shallow = true
 [submodule "ThirdParty/tbb"]
 	path = ThirdParty/tbb
 	url = https://github.com/wjakob/tbb.git
-	shallow = true
 [submodule "ThirdParty/pybind11"]
 	path = ThirdParty/pybind11
 	url = https://github.com/pybind/pybind11.git


### PR DESCRIPTION
Shallow cloning allows only to clone relatively new commits