### PR TITLE
Fit fraction rework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,6 @@ find_package(Threads REQUIRED)
 
 find_package(ROOT COMPONENTS Minuit2)
 
-find_package(GSL COMPONENTS gsl gslcblas REQUIRED)
-
 # Geneva minimizer module (optional)
 option(USE_GENEVA "Switch Geneva On/Off" ON)
 if(USE_GENEVA)

--- a/Examples/DalitzFit/CMakeLists.txt
+++ b/Examples/DalitzFit/CMakeLists.txt
@@ -11,7 +11,7 @@ set(lib_srcs DalitzFitApp.cpp)
 add_executable(DalitzFit DalitzFitApp.cpp)
 
 target_link_libraries( DalitzFit
-    Minuit2IF MinLogLH RootData Integration Plotting HelicityFormalism
+    Minuit2IF MinLogLH RootData Integration Plotting HelicityFormalism Tools
 )
 
 target_include_directories( DalitzFit

--- a/Examples/DalitzFit/DalitzFitApp.cpp
+++ b/Examples/DalitzFit/DalitzFitApp.cpp
@@ -253,7 +253,7 @@ int main(int argc, char **argv) {
 
   ComPWA::Data::Root::RootUniformRealGenerator RandomGenerator(173);
 
-  auto phspSample(ComPWA::Data::generatePhsp(1000000, gen, RandomGenerator));
+  auto phspSample(ComPWA::Data::generatePhsp(100000, gen, RandomGenerator));
 
   //---------------------------------------------------
   // 3) Create intensity from pre-defined model
@@ -292,10 +292,17 @@ int main(int argc, char **argv) {
   LOG(INFO) << result;
 
   // calculate fit fractions and errors
-  auto components = Builder.createIntensityComponents();
+  auto components = Builder.createIntensityComponents(
+      {{"f2(1270)"}, {"myAmp"}, {"jpsiGammaPiPi"}});
+
+  auto MyFractions = {std::make_pair(components[0], components[2]),
+                      std::make_pair(components[1], components[2])};
+
   ComPWA::Tools::FitFractions FF;
   auto FitFractionList = FF.calculateFitFractionsWithCovarianceErrorPropagation(
-      components, Data::convertEventsToDataSet(phspSample, kin), result);
+      MyFractions, Data::convertEventsToDataSet(phspSample, kin), result);
+
+  LOG(INFO) << FitFractionList;
 
   //---------------------------------------------------
   // 5.1) Save the fit result

--- a/Examples/DalitzFit/DalitzFitApp.cpp
+++ b/Examples/DalitzFit/DalitzFitApp.cpp
@@ -272,16 +272,13 @@ int main(int argc, char **argv) {
   //---------------------------------------------------
   // 4) Generate a data sample given intensity and kinematics
   //---------------------------------------------------
-
   auto sample =
       ComPWA::Data::generate(1000, kin, RandomGenerator, intens, phspSample);
 
+  auto SampleDataSet = Data::convertEventsToDataSet(sample, kin);
   //---------------------------------------------------
   // 5) Fit the model to the data and print the result
   //---------------------------------------------------
-
-  auto SampleDataSet = Data::convertEventsToDataSet(sample, kin);
-
   auto esti = ComPWA::Estimator::createMinLogLHFunctionTreeEstimator(
       intens, SampleDataSet);
 
@@ -292,9 +289,13 @@ int main(int argc, char **argv) {
   // STARTING MINIMIZATION
   auto result = minuitif.optimize(std::get<0>(esti), std::get<1>(esti));
 
-  // TODO: do fit fraction calculation part
-
   LOG(INFO) << result;
+
+  // calculate fit fractions and errors
+  auto components = Builder.createIntensityComponents();
+  ComPWA::Tools::FitFractions FF;
+  auto FitFractionList = FF.calculateFitFractionsWithCovarianceErrorPropagation(
+      components, Data::convertEventsToDataSet(phspSample, kin), result);
 
   //---------------------------------------------------
   // 5.1) Save the fit result

--- a/Examples/test/FitTest/CMakeLists.txt
+++ b/Examples/test/FitTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(TARGET Data AND TARGET HelicityFormalism)
+if(TARGET RootData AND TARGET HelicityFormalism)
 
 set(testSrc
   FitTest.cpp

--- a/Physics/BuilderXML.cpp
+++ b/Physics/BuilderXML.cpp
@@ -381,7 +381,7 @@ IntensityBuilderXML::createIntegrationStrategyFT(
     tr->createNode("Integral",
                    std::shared_ptr<Strategy>(new MultAll(ParType::DOUBLE)),
                    NodeName);
-    // normTree->createLeaf("PhspVolume", PhspVolume, "Integral");
+    tr->createLeaf("PhspVolume", Kinematic.phspVolume(), "Integral");
     tr->createLeaf("InverseSampleWeights", 1.0 / PhspWeightSum, "Integral");
     tr->createNode("Sum",
                    std::shared_ptr<Strategy>(new AddAll(ParType::DOUBLE)),

--- a/Physics/BuilderXML.hpp
+++ b/Physics/BuilderXML.hpp
@@ -5,17 +5,20 @@
 #ifndef COMPWA_PHYSICS_BUILDERXML_HPP_
 #define COMPWA_PHYSICS_BUILDERXML_HPP_
 
-#include <memory>
-#include <tuple>
-#include <vector>
-
 #include "Core/Function.hpp"
 #include "Core/FunctionTree/FunctionTreeIntensity.hpp"
 #include "Core/FunctionTree/Value.hpp"
 #include "Data/DataSet.hpp"
 #include "Physics/ParticleStateTransitionKinematicsInfo.hpp"
+#include "Tools/FitFractions.hpp"
 
 #include <boost/property_tree/ptree_fwd.hpp>
+
+#include <map>
+#include <memory>
+#include <set>
+#include <tuple>
+#include <vector>
 
 namespace ComPWA {
 class Kinematics;
@@ -37,6 +40,9 @@ public:
 
   ComPWA::FunctionTree::FunctionTreeIntensity createIntensity();
 
+  std::vector<ComPWA::Tools::IntensityComponent> createIntensityComponents(
+      std::vector<std::vector<std::string>> ComponentList = {});
+
 private:
   struct IntensityBuilderState {
     ComPWA::FunctionTree::ParameterList Parameters;
@@ -54,8 +60,21 @@ private:
                               std::string suffix);
 
   std::shared_ptr<ComPWA::FunctionTree::FunctionTree>
+  createIncoherentIntensityFT(
+      std::string Name,
+      std::vector<std::shared_ptr<ComPWA::FunctionTree::FunctionTree>>
+          Intensities,
+      std::string suffix);
+
+  std::shared_ptr<ComPWA::FunctionTree::FunctionTree>
   createCoherentIntensityFT(const boost::property_tree::ptree &pt,
                             std::string suffix);
+
+  std::shared_ptr<ComPWA::FunctionTree::FunctionTree> createCoherentIntensityFT(
+      std::string Name,
+      std::vector<std::shared_ptr<ComPWA::FunctionTree::FunctionTree>>
+          Amplitudes,
+      std::string suffix);
 
   std::shared_ptr<ComPWA::FunctionTree::FunctionTree>
   createStrengthIntensityFT(const boost::property_tree::ptree &pt,
@@ -94,6 +113,15 @@ private:
 
   void updateDataContainerState();
 
+  void addFunctionTreeComponent(
+      std::string Name, std::string Type,
+      std::shared_ptr<ComPWA::FunctionTree::FunctionTree> FT);
+
+  std::map<std::string,
+           std::pair<std::string,
+                     std::shared_ptr<ComPWA::FunctionTree::FunctionTree>>>
+      UniqueComponentFTMapping;
+
   ParticleList PartList;
   Kinematics &Kinematic;
   boost::property_tree::ptree ModelTree;
@@ -106,12 +134,6 @@ private:
 HelicityFormalism::HelicityKinematics
 createHelicityKinematics(const ComPWA::ParticleList &PartList,
                          const boost::property_tree::ptree &pt);
-
-ParticleStateTransitionKinematicsInfo
-createKinematicsInfo(const ComPWA::ParticleList &PartList,
-                     const boost::property_tree::ptree &pt);
-
-FourMomentum createFourMomentum(const boost::property_tree::ptree &pt);
 
 } // namespace Physics
 } // namespace ComPWA

--- a/Tools/CMakeLists.txt
+++ b/Tools/CMakeLists.txt
@@ -1,11 +1,5 @@
-#################
-# Tools Library #
-#################
-
-# Check if all requirements are found. Skip modules otherwise.
-if(${GSL_FOUND})
-
 set(lib_srcs
+  FitFractions.cpp
   UpdatePTreeParameter.cpp
 )
 set(lib_headers
@@ -21,7 +15,6 @@ add_library(Tools
 target_link_libraries(Tools
   PUBLIC
   	Core Integration
-    GSL::gsl GSL::gslcblas
 )
 
 target_include_directories(Tools
@@ -33,9 +26,6 @@ install(TARGETS Tools
     ARCHIVE DESTINATION lib
 )
 
-else ()
-  message(WARNING "Requirements not found! Not building Tools module!")
-endif()
 
 add_library(Integration
   Integration.cpp Integration.hpp

--- a/Tools/FitFractions.cpp
+++ b/Tools/FitFractions.cpp
@@ -1,0 +1,222 @@
+#include "FitFractions.hpp"
+
+#include "Core/FitResult.hpp"
+#include "Core/Function.hpp"
+#include "Core/Logging.hpp"
+#include "Core/ProgressBar.hpp"
+#include "Data/DataSet.hpp"
+#include "Tools/Integration.hpp"
+
+#include <map>
+
+namespace ComPWA {
+namespace Tools {
+
+std::ostream &operator<<(std::ostream &os, const FitFractionList &FFList) {
+  os << "\nFit Fractions:\n";
+  for (auto const &ff : FFList) {
+    os << ff.Name << ": " << ff.Value << " +- " << ff.Error << "\n";
+  }
+  return os;
+}
+
+/// Calculates the fit fractions with errors via error propagation from the
+/// covariance matrix. The gradients are calculated via numerical
+/// differentiation:
+/// \f[
+/// f´(x) = \frac{f(x+h) - f(x-h)}{2h} + O(h^2)
+/// \f]
+FitFractionList
+FitFractions::calculateFitFractionsWithCovarianceErrorPropagation(
+    const std::vector<std::pair<IntensityComponent, IntensityComponent>>
+        &Components,
+    const ComPWA::Data::DataSet &PhspSample, const ComPWA::FitResult &Result) {
+  FitFractionList FitFractions;
+
+  for (auto Component : Components) {
+    auto NumeratorData = getIntegralData(Component.first, PhspSample, Result);
+    auto DenominatorData =
+        getIntegralData(Component.second, PhspSample, Result);
+
+    double FitFractionValue =
+        std::get<1>(NumeratorData) / std::get<1>(DenominatorData);
+
+    // FF = N/D -> calculate Jacobi matrix (because we have a single ff, this is
+    // just a vector)
+    std::vector<double> JacobiColumn;
+    std::vector<std::vector<double>> CovMatrix;
+    std::tie(JacobiColumn, CovMatrix) = buildJacobiAndCovariance(
+        std::make_tuple(std::get<1>(NumeratorData), std::get<2>(NumeratorData)),
+        std::make_tuple(std::get<1>(DenominatorData),
+                        std::get<2>(DenominatorData)),
+        Result);
+
+    double FitFractionError(0.0);
+    // calculate J^T x Cov x J
+    for (unsigned int i = 0; i < JacobiColumn.size(); ++i) {
+      for (unsigned int j = 0; j < JacobiColumn.size(); ++j) {
+        FitFractionError +=
+            Result.CovarianceMatrix[i][j] * JacobiColumn[i] * JacobiColumn[j];
+      }
+    }
+
+    FitFractions.push_back(
+        {std::get<0>(NumeratorData) + "/" + std::get<0>(DenominatorData),
+         FitFractionValue, FitFractionError});
+  }
+
+  // the fit fraction errors are currently the squared values, take a sqrt
+  for (auto &f : FitFractions) {
+    f.Error = std::sqrt(f.Error);
+    LOG(TRACE) << "calculateFitFractionsWithCovarianceErrorPropagation(): fit "
+                  "fraction for ("
+               << f.Name << ") is " << f.Value << " +- " << f.Error;
+  }
+
+  return FitFractions;
+}
+
+std::tuple<std::vector<double>, std::vector<std::vector<double>>>
+FitFractions::buildJacobiAndCovariance(
+    const std::tuple<double, std::vector<DerivativeData>> &NominatorDerivatives,
+    const std::tuple<double, std::vector<DerivativeData>>
+        &DenominatorDerivatives,
+    const ComPWA::FitResult &Result) {
+  std::vector<double> Column;
+  std::vector<size_t> ParameterPositions;
+
+  double N = std::get<0>(NominatorDerivatives);
+  double D = std::get<0>(DenominatorDerivatives);
+
+  auto dN = std::get<1>(NominatorDerivatives);
+  auto dD = std::get<1>(DenominatorDerivatives);
+
+  size_t PositionCounter(0);
+  for (auto x : Result.FinalParameters) {
+    if (x.IsFixed)
+      continue;
+    auto FoundNominator =
+        std::find_if(dN.begin(), dN.end(), [&x](auto const &par) {
+          return par.ParameterName == x.Name;
+        });
+    auto FoundDenominator =
+        std::find_if(dD.begin(), dD.end(), [&x](auto const &par) {
+          return par.ParameterName == x.Name;
+        });
+    if (dN.end() != FoundNominator && dD.end() != FoundDenominator) {
+      // if both derivatives != 0
+      Column.push_back((FoundNominator->ValueAtParameterPlusEpsilon /
+                            FoundDenominator->ValueAtParameterPlusEpsilon -
+                        FoundNominator->ValueAtParameterMinusEpsilon /
+                            FoundDenominator->ValueAtParameterMinusEpsilon) /
+                       FoundNominator->StepSize);
+    } else if (dN.end() != FoundNominator) {
+      // if only nominator derivative != 0
+      Column.push_back((FoundNominator->ValueAtParameterPlusEpsilon / D -
+                        FoundNominator->ValueAtParameterMinusEpsilon / D) /
+                       FoundNominator->StepSize);
+    } else if (dD.end() != FoundDenominator) {
+      // if only denominator derivative != 0
+      Column.push_back((N / FoundDenominator->ValueAtParameterPlusEpsilon -
+                        N / FoundDenominator->ValueAtParameterMinusEpsilon) /
+                       FoundDenominator->StepSize);
+    } else {
+      ++PositionCounter;
+      continue;
+    }
+    ParameterPositions.push_back(PositionCounter);
+    ++PositionCounter;
+  }
+
+  std::vector<std::vector<double>> SubCovarianceMatrix(
+      ParameterPositions.size(),
+      std::vector<double>(ParameterPositions.size()));
+  for (size_t i = 0; i < ParameterPositions.size(); ++i) {
+    for (size_t j = 0; j < ParameterPositions.size(); ++j) {
+      SubCovarianceMatrix[i][j] =
+          Result.CovarianceMatrix[ParameterPositions[i]][ParameterPositions[j]];
+    }
+  }
+
+  return std::make_tuple(Column, SubCovarianceMatrix);
+}
+
+std::tuple<std::string, double, std::vector<FitFractions::DerivativeData>>
+FitFractions::getIntegralData(IntensityComponent IntensComponent,
+                              const ComPWA::Data::DataSet &PhspSample,
+                              const ComPWA::FitResult &Result) {
+  std::string Name(IntensComponent.first);
+
+  // only calculated the integrals if they have not once before
+  auto FoundIntegrals = IntensityGradientDataMapping.find(Name);
+
+  if (IntensityGradientDataMapping.end() == FoundIntegrals) {
+    ComPWA::initializeWithFitResult(*IntensComponent.second, Result);
+
+    FoundIntegrals =
+        IntensityGradientDataMapping
+            .insert({Name, calculateIntensityIntegralData(
+                               *IntensComponent.second, PhspSample, Result)})
+            .first;
+  }
+  return std::tuple_cat(std::make_tuple(FoundIntegrals->first),
+                        FoundIntegrals->second);
+}
+
+std::tuple<double, std::vector<FitFractions::DerivativeData>>
+FitFractions::calculateIntensityIntegralData(
+    ComPWA::Intensity &Intens, const ComPWA::Data::DataSet &Sample,
+    const ComPWA::FitResult &Result) {
+
+  double Integral = ComPWA::Tools::integrate(Intens, Sample);
+
+  std::vector<Parameter> TempParameters = Intens.getParameters();
+  std::vector<double> TempParameterValues;
+  for (auto const &x : TempParameters)
+    TempParameterValues.push_back(x.Value);
+
+  std::vector<DerivativeData> Derivatives;
+  for (unsigned int i = 0; i < TempParameters.size(); ++i) {
+    auto found = std::find_if(Result.FinalParameters.begin(),
+                              Result.FinalParameters.end(),
+                              [refname = TempParameters[i].Name](
+                                  auto const &p) { return p.Name == refname; });
+    if (Result.FinalParameters.end() != found) {
+      if (found->IsFixed) {
+        continue;
+      }
+      double TempValue = found->Value;
+
+      // a step size of sqrt(epsilon) * x produces small rounding errors
+      double h = std::sqrt(std::numeric_limits<double>::epsilon());
+      if (TempValue != 0.0)
+        h *= TempValue;
+
+      DerivativeData GradientData;
+      GradientData.ParameterName = TempParameters[i].Name;
+      double up(TempValue + h);
+      TempParameterValues[i] = up;
+      Intens.updateParametersFrom(TempParameterValues);
+      GradientData.ValueAtParameterPlusEpsilon =
+          ComPWA::Tools::integrate(Intens, Sample);
+
+      double down(TempValue - h);
+      TempParameterValues[i] = down;
+      GradientData.StepSize = up - down;
+      // if the compiler optimizes the above line with math associativity
+      // (by setting it to 2*h), then we get an additional numerical error
+      Intens.updateParametersFrom(TempParameterValues);
+      GradientData.ValueAtParameterMinusEpsilon =
+          ComPWA::Tools::integrate(Intens, Sample);
+
+      Derivatives.push_back(GradientData);
+
+      // reset values
+      TempParameterValues[i] = TempValue;
+    }
+  }
+  return std::make_tuple(Integral, Derivatives);
+}
+
+} // namespace Tools
+} // namespace ComPWA

--- a/Tools/FitFractions.hpp
+++ b/Tools/FitFractions.hpp
@@ -5,364 +5,75 @@
 #ifndef COMPWA_TOOLS_FITFRACTIONS_HPP_
 #define COMPWA_TOOLS_FITFRACTIONS_HPP_
 
+#include "Core/Function.hpp"
+
+#include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
-#include "Core/FitResult.hpp"
-#include "Core/ProgressBar.hpp"
-#include "Data/DataSet.hpp"
-#include "Tools/Integration.hpp"
-
-#include <gsl/gsl_blas.h>
-#include <gsl/gsl_linalg.h>
-#include <gsl/gsl_matrix.h>
-#include <gsl/gsl_randist.h>
-#include <gsl/gsl_rng.h>
-#include <gsl/gsl_sf_gamma.h>
-#include <gsl/gsl_vector.h>
-
 namespace ComPWA {
+struct FitResult;
+class Kinematics;
+namespace Data {
+struct DataSet;
+}
 namespace Tools {
 
 struct FitFraction {
-  FitFraction(std::string name, double val, double err)
-      : Name(name), Value(val), Error(err) {}
-  FitFraction(std::string name, double val) : FitFraction(name, val, 0.0) {}
-
   std::string Name;
   double Value;
   double Error;
 };
+
 using FitFractionList = std::vector<FitFraction>;
-/*
-/// Print gsl_matrix
-inline void gsl_matrix_print(const gsl_matrix *m) {
-  for (size_t i = 0; i < m->size1; i++) {
-    for (size_t j = 0; j < m->size2; j++) {
-      printf("%g ", gsl_matrix_get(m, i, j));
-    }
-    printf("\n");
-  }
+
+using IntensityComponent = std::pair<std::string, std::shared_ptr<Intensity>>;
+
+std::ostream &operator<<(std::ostream &os, const FitFractionList &FFList);
+
+class FitFractions {
+public:
+  /// Calculates the fit fractions with errors via error propagation from the
+  /// covariance matrix. The gradients are calculated via numerical
+  /// differentiation:
+  /// \f[
+  /// f´(x) = \frac{f(x+h) - f(x-h)}{2h} + O(h^2)
+  /// \f]
+  FitFractionList calculateFitFractionsWithCovarianceErrorPropagation(
+      const std::vector<std::pair<IntensityComponent, IntensityComponent>>
+          &Components,
+      const ComPWA::Data::DataSet &PhspSample, const ComPWA::FitResult &Result);
+
+private:
+  // internal helper structure, hidden from user
+  struct DerivativeData {
+    std::string ParameterName;
+    double ValueAtParameterPlusEpsilon;
+    double ValueAtParameterMinusEpsilon;
+    double StepSize;
+  };
+
+  std::map<std::string, std::tuple<double, std::vector<DerivativeData>>>
+      IntensityGradientDataMapping;
+
+  std::tuple<std::vector<double>, std::vector<std::vector<double>>>
+  buildJacobiAndCovariance(const std::tuple<double, std::vector<DerivativeData>>
+                               &NominatorDerivatives,
+                           const std::tuple<double, std::vector<DerivativeData>>
+                               &DenominatorDerivatives,
+                           const ComPWA::FitResult &Result);
+
+  std::tuple<std::string, double, std::vector<FitFractions::DerivativeData>>
+  getIntegralData(IntensityComponent IntensComponent,
+                  const ComPWA::Data::DataSet &PhspSample,
+                  const ComPWA::FitResult &Result);
+
+  std::tuple<double, std::vector<FitFractions::DerivativeData>>
+  calculateIntensityIntegralData(ComPWA::Intensity &Intens,
+                                 const ComPWA::Data::DataSet &PhspSample,
+                                 const ComPWA::FitResult &Result);
 };
-
-/// Convert ParameterList to gsl vector
-inline gsl_vector *gsl_parameterList2Vec(const ParameterList &list) {
-  size_t n = list.doubleParameters().size();
-  gsl_vector *tmp = gsl_vector_alloc(n);
-  size_t t = 0;
-  for (size_t o = 0; o < n; o++) {
-    auto outPar = list.doubleParameter(o);
-    if (outPar->isFixed())
-      continue;
-    gsl_vector_set(tmp, t, outPar->value());
-    t++;
-  }
-  // resize vector
-  gsl_vector *vec = gsl_vector_alloc(t);
-  for (unsigned int i = 0; i < vec->size; i++)
-    gsl_vector_set(vec, i, gsl_vector_get(tmp, i));
-  return vec;
-};
-
-/// Convert std::vector matrix to gsl matrix
-inline gsl_matrix *
-gsl_vecVec2Matrix(const std::vector<std::vector<double>> &m) {
-  gsl_matrix *tmp = gsl_matrix_alloc(m.size(), m.at(0).size());
-  for (size_t i = 0; i < tmp->size1; i++) {
-    for (unsigned int j = 0; j < tmp->size2; j++) {
-      gsl_matrix_set(tmp, i, j, m.at(i).at(j));
-    }
-  }
-  return tmp;
-};
-
-/// Multivariate Gaussian using cholesky decomposition
-/// A test application can be found at test/MultiVariateGaussianTestApp.cpp
-///
-/// \param rnd Random number generator
-/// \param vecSize Size of data vector
-/// \param in Mean value(s)
-/// \param cov Covariance matrix
-/// \param res Resulting Vector
-inline void multivariateGaussian(const gsl_rng *rnd, const unsigned int vecSize,
-                                 const gsl_vector *in, const gsl_matrix *cov,
-                                 gsl_vector *res) {
-  // Generate and fill temporary covariance matrix
-  gsl_matrix *tmpM = gsl_matrix_alloc(vecSize, vecSize);
-  gsl_matrix_memcpy(tmpM, cov);
-
-  // Cholesky decomposition
-  int status = gsl_linalg_cholesky_decomp(tmpM);
-  if (status == GSL_EDOM)
-    LOG(ERROR) << "Decomposition has failed!";
-
-  // Compute vector of random gaussian variables
-  for (unsigned int i = 0; i < vecSize; i++)
-    gsl_vector_set(res, i, gsl_ran_ugaussian(rnd));
-
-  // Debug
-  //  gsl_matrix_print(cov);
-  //  gsl_vector_print(in);
-  //  gsl_vector_print(res);
-  //  gsl_matrix_print(tmpM);
-
-  // From the GNU GSL Documentation:
-  // The function dtrmv compute the matrix-vector product x = op(A) x for the
-  // triangular matrix A, where op(A) = A, A^T, A^H for TransA = CblasNoTrans,
-  // CblasTrans, CblasConjTrans. When Uplo is CblasUpper then the upper
-  // triangle of A is used, and when Uplo is CblasLower then the lower
-  // triangle of A is used. If Diag is CblasNonUnit then the diagonal of
-  // the matrix is used, but if Diag is CblasUnit then the diagonal elements
-  // of the matrix A are taken as unity and are not referenced.
-  gsl_blas_dtrmv(CblasLower, CblasNoTrans, CblasNonUnit, tmpM, res);
-
-  gsl_vector_add(res, in);
-  // free temporary object
-  gsl_matrix_free(tmpM);
-};*/
-
-/// Calculates the fit fractions using the formula:
-/// \f[
-///  f_i = \frac{|c_i|^2 \int A_i A_i^*}{\int \sum c_l c_m^* A_l A_m^*}
-/// \f]
-/// The \f$c_i\f$ are the complex coefficient of the amplitudes \f$A_i\f$ and
-/// the denominator is the integral over the whole intensity.
-/// The integrals are performed via Monte Carlo integration method.
-FitFractionList calculateFitFractions(
-    std::map<std::string, std::shared_ptr<ComPWA::Intensity>> Nominators,
-    std::shared_ptr<ComPWA::Intensity> Denominator,
-    const ComPWA::Data::DataSet &sample) {
-  LOG(DEBUG) << "calculating fit fractions...";
-
-  FitFractionList result;
-  // calculate denominator
-  double IntegralDenominator = ComPWA::Tools::integrate(*Denominator, sample);
-
-  // TODO: ultimately we want to have all combinations of amplitudes
-  // A_i x A_j*
-  // so loop over the amplitudes and in the second loop start with the same
-  // index
-  // -in that way we will only calculate one half of the matrix, plus the
-  // diagonal
-  // -then we need a complexconjugate amplitudedecorator, which we can
-  // use here to perform the operation!
-
-  // calculate nominators
-  for (auto x : Nominators) {
-    double IntegralNumerator = ComPWA::Tools::integrate(*x.second, sample);
-
-    double fitfraction = IntegralNumerator / IntegralDenominator;
-    LOG(TRACE) << "calculateFitFractions(): fit fraction for (" << x.first
-               << ") is " << fitfraction;
-
-    result.push_back(FitFraction(x.first, fitfraction));
-  }
-  LOG(DEBUG) << "finished fit fraction calculation!";
-  return result;
-}
-
-/// Calculates the fit fractions with errors.
-/// The errors are calculated by generating sets of fit parameters that are
-/// smeared by a multidimensional gaussian using the covariance matrix of the
-/// fit. For every set the fit fractions are calculated. From this distribution
-/// the standard errors give the errors of the fit fractions. This can be a very
-/// time consuming method.
-/*FitFractionList calculateFitFractionsWithSampledError(
-    std::shared_ptr<ComPWA::Physics::CoherentIntensity> CohIntensity,
-    std::shared_ptr<ComPWA::Data::DataSet> Sample,
-    const std::vector<std::vector<double>> &covariance, size_t nSets,
-    const std::vector<std::string> &Components = {}) {
-
-  auto FitFractions = calculateFitFractions(CohIntensity, Sample, Components);
-
-  LOG(INFO) << "calculateFitFractionsWithErrorSampling(): Calculating errors "
-               "of fit fractions using "
-            << nSets << " sets of parameters...";
-
-  // in principle a copy of the intensity should be made to not interfere with
-  // the constness
-  auto intens =
-      std::const_pointer_cast<ComPWA::Physics::CoherentIntensity>(CohIntensity);
-
-  ParameterList parameters;
-  intens->addUniqueParametersTo(parameters);
-
-  if (nSets <= 0)
-    return FitFractions;
-  if (!parameters.doubleParameters().size())
-    return FitFractions;
-
-  size_t NumberOfFreeParameters(0);
-  for (auto const &x : parameters.doubleParameters()) {
-    if (!x->isFixed())
-      ++NumberOfFreeParameters;
-  }
-  if (NumberOfFreeParameters != covariance.size())
-    return FitFractions;
-
-  // Check whether covariance matrix is set to zero.
-  bool leave = true;
-  for (unsigned int i = 0; i < covariance.size(); ++i)
-    for (unsigned int j = 0; j < covariance.size(); ++j)
-      if (covariance.at(i).at(j) != 0.)
-        leave = false;
-  if (leave)
-    LOG(ERROR) << "CalcFractionError() | Covariance matrix is zero "
-                  "(everywhere)! We skip further "
-                  "calculation of fit fraction errors.";
-
-  // Setting up random number generator
-  const gsl_rng_type *T;
-  gsl_rng_env_setup();
-  T = gsl_rng_default;
-  gsl_rng *rnd = gsl_rng_alloc(T);
-
-  // convert to GSL objects
-  gsl_vector *gslFinalPar = gsl_parameterList2Vec(parameters);
-  gsl_matrix *gslCov = gsl_vecVec2Matrix(covariance);
-  gsl_matrix_print(gslCov); // DEBUG
-
-  int nFreeParameter = covariance.size();
-
-  ParameterList originalPar;
-  originalPar.DeepCopy(parameters);
-
-  std::vector<ParameterList> fracVect;
-  ProgressBar bar(nSets);
-  unsigned int i = 0;
-  while (i < nSets) {
-    bool error = 0;
-    gsl_vector *gslNewPar = gsl_vector_alloc(nFreeParameter);
-    // generate set of smeared parameters
-    multivariateGaussian(rnd, nFreeParameter, gslFinalPar, gslCov, gslNewPar);
-    // gsl_vector_print(gslNewPar); // Debug
-
-    // deep copy of finalParameters
-    ParameterList newPar;
-    newPar.DeepCopy(parameters);
-
-    std::size_t t = 0;
-    for (std::size_t o = 0; o < newPar.doubleParameters().size(); o++) {
-      std::shared_ptr<FitParameter> outPar = newPar.doubleParameter(o);
-      if (outPar->isFixed())
-        continue;
-      // set floating values to smeared values
-      try { // catch out-of-bound
-        outPar->setValue(gslNewPar->data[t]);
-      } catch (ParameterOutOfBound &ex) {
-        error = 1;
-      }
-      t++;
-    }
-    if (error)
-      continue; // skip this set if one parameter is out of bound
-
-    // free vector
-    gsl_vector_free(gslNewPar);
-    // update amplitude with smeared parameters
-    try {
-      intens->updateParametersFrom(newPar);
-    } catch (ParameterOutOfBound &ex) {
-      continue;
-    }
-    fracVect.push_back(calculateFitFractions(intens, Sample, Components));
-    bar.next();
-    i++;
-  }
-
-  // free objects
-  gsl_vector_free(gslFinalPar);
-  gsl_matrix_free(gslCov);
-  gsl_rng_free(rnd);
-
-  // Calculate standard deviation
-  for (unsigned int o = 0; o < FitFractions.doubleParameters().size(); ++o) {
-    double mean = 0, sqSum = 0., stdev = 0;
-    for (unsigned int i = 0; i < fracVect.size(); ++i) {
-      double tmp = fracVect.at(i).doubleParameter(o)->value();
-      mean += tmp;
-      sqSum += tmp * tmp;
-    }
-    unsigned int s = fracVect.size();
-    sqSum /= s;
-    mean /= s;
-    // Equivalent to RMS of the distribution
-    stdev = std::sqrt(sqSum - mean * mean);
-    FitFractions.doubleParameter(o)->setError(stdev);
-  }
-
-  intens->updateParametersFrom(originalPar);
-  return FitFractions;
-}*/
-
-/// Calculates the fit fractions with errors via error propagation from the
-/// covariance matrix. The gradients are calculated via numerical
-/// differentiation:
-/// \f[
-/// f'(x) = \frac{f(x+h) - f(x-h)}{2h} + O(h^2)
-/// \f]
-FitFractionList calculateFitFractionsWithCovarianceErrorPropagation(
-    std::map<std::string, std::shared_ptr<ComPWA::Intensity>> Nominators,
-    std::shared_ptr<ComPWA::Intensity> Denominator,
-    const ComPWA::Data::DataSet &Sample, ComPWA::FitResult Result) {
-
-  auto FitFractions = calculateFitFractions(Nominators, Denominator, Sample);
-
-  std::vector<ComPWA::Parameter> TempParameters = Denominator->getParameters();
-
-  std::vector<std::vector<double>> Gradients;
-  /*
-    for (double Par : TempParameters) {
-      if (FitPar->isFixed())
-        continue;
-      double TempValue = FitPar->value();
-
-      double h = std::sqrt(std::numeric_limits<double>::epsilon()) * TempValue;
-
-      FitPar->setValue(TempValue + h);
-      intens->updateParametersFrom(TempParameters);
-      ParameterList ff_ph = calculateFitFractions(intens, Sample, Components);
-
-      FitPar->setValue(TempValue - h);
-      intens->updateParametersFrom(TempParameters);
-      ParameterList ff_mh = calculateFitFractions(intens, Sample, Components);
-
-      size_t NumberOfFitFractions(ff_ph.doubleParameters().size());
-      ParameterList FitFractionGradients;
-      for (size_t i = 0; i < NumberOfFitFractions; ++i) {
-        FitFractionGradients.addParameter(std::make_shared<ComPWA::FitParameter>(
-            ff_ph.doubleParameter(i)->name(),
-            (ff_ph.doubleParameter(i)->value() -
-             ff_mh.doubleParameter(i)->value()) /
-                (2. * h)));
-      }
-      Gradients.push_back(FitFractionGradients);
-      FitPar->setValue(TempValue);
-    }
-
-    std::vector<double>
-    FitFractionErrors(FitFractions.doubleParameters().size());
-
-    for (unsigned int ffi = 0; ffi < FitFractionErrors.size(); ++ffi) {
-      for (unsigned int par1 = 0; par1 < Gradients.size(); ++par1) {
-        for (unsigned int par2 = 0; par2 < Gradients.size(); ++par2) {
-          FitFractionErrors[ffi] +=
-              CovarianceMatrix[par1][par2] *
-              Gradients[par1].doubleParameter(ffi)->value() *
-              Gradients[par2].doubleParameter(ffi)->value();
-        }
-      }
-    }
-
-    for (unsigned int ffi = 0; ffi < FitFractionErrors.size(); ++ffi) {
-      FitFractions.doubleParameter(ffi)->setError(
-          std::sqrt(FitFractionErrors[ffi]));
-    }
-
-    intens->updateParametersFrom(PreviousParameters);
-  */
-  return FitFractions;
-}
 
 } // namespace Tools
 } // namespace ComPWA


### PR DESCRIPTION
This update brings back the fit fraction functionality! Now various fit fractions can be constructed, based on the name of the Amplitudes or Intensities. Some example code on how to use the new fit fraction functionality can be seen in the DalitzFitApp.

I made some rough comparison of the fit fraction results of the DalitzFitApp. But since a lot of things have changed since the fit fraction functionality was working, it is almost impossible to get a 100% match.

Let me know what you think. I will change the commit messages once we are closer to finalizing the pull request. 