### PR TITLE
Stricter Doxygen test

### DIFF
--- a/Core/FunctionTree/FunctionTree.hpp
+++ b/Core/FunctionTree/FunctionTree.hpp
@@ -22,7 +22,7 @@ namespace ComPWA {
 namespace FunctionTree {
 
 ///
-/// \class FunctionTree for automatically cashing of mathematical expressions.
+/// FunctionTree for automatically cashing of mathematical expressions.
 /// This class can be used to store a function in a tree-like structure. Parts
 /// of the tree that were calculated before and have not been changed are
 /// cashed. This reduces the amount of recalculation at evaluation time.

--- a/Core/FunctionTree/ParObserver.hpp
+++ b/Core/FunctionTree/ParObserver.hpp
@@ -14,7 +14,7 @@ namespace ComPWA {
 namespace FunctionTree {
 
 ///
-/// \class ParObserver Base class parameter observer.
+/// ParObserver Base class parameter observer.
 /// For the use in the function tree, the observer pattern is used.
 /// This class takes the role of the Observer. It's implemented by the
 /// TreeNode class, which then are able to observe a parameter and note

--- a/Core/FunctionTree/ParameterList.cpp
+++ b/Core/FunctionTree/ParameterList.cpp
@@ -65,9 +65,9 @@ void ParameterList::addParameters(
     addParameter(i);
 }
 
-std::shared_ptr<FunctionTree::FitParameter> ParameterList::addUniqueParameter(
-    std::shared_ptr<FunctionTree::FitParameter> par) {
-  std::shared_ptr<FunctionTree::FitParameter> tmp;
+std::shared_ptr<FitParameter> ParameterList::addUniqueParameter(
+    std::shared_ptr<FitParameter> par) {
+  std::shared_ptr<FitParameter> tmp;
   try {
     tmp = FindParameter(par->name(), FitParameters);
   } catch (std::exception &ex) {
@@ -84,7 +84,7 @@ std::shared_ptr<FunctionTree::FitParameter> ParameterList::addUniqueParameter(
 }
 
 void ParameterList::addParameter(
-    std::shared_ptr<FunctionTree::FitParameter> par) {
+    std::shared_ptr<FitParameter> par) {
   FitParameters.push_back(
       std::dynamic_pointer_cast<FunctionTree::FitParameter>(par));
 }

--- a/Core/FunctionTree/TreeNode.hpp
+++ b/Core/FunctionTree/TreeNode.hpp
@@ -25,7 +25,7 @@ namespace FunctionTree {
 class FunctionTree;
 
 ///
-/// \class TreeNode is the interface for elements of the FunctionTree
+/// TreeNode is the interface for elements of the FunctionTree
 /// This class acts as a container for a parameter in a function tree. It has a
 /// Strategy to calculate its value and a name.
 ///

--- a/Data/Root/RootDataIO.cpp
+++ b/Data/Root/RootDataIO.cpp
@@ -26,7 +26,7 @@ RootDataIO::RootDataIO(const std::string TreeName_, std::size_t NumberEventsToPr
 
 std::vector<ComPWA::Event>
 RootDataIO::readData(const std::string &InputFilePath) const {
-  /// @TODO Use of `TChain` in this way may result in run-time errors for larger
+  /// @todo Use of `TChain` in this way may result in run-time errors for larger
   /// data samples.
   TChain chain(TreeName.c_str());
   chain.Add(InputFilePath.c_str());

--- a/Data/Root/RootDataIO.hpp
+++ b/Data/Root/RootDataIO.hpp
@@ -31,7 +31,7 @@ public:
   RootDataIO(const std::string TreeName_ = "data",
              std::size_t NumberEventsToProcess_ = -1);
 
-  /// @param InpufFilePath Input file(s); can take wildcards, because it uses [`TChain::Add`](https://root.cern.ch/doc/master/classTChain.html).
+  /// @param InputFilePath Input file(s); can take wildcards, because it uses [`TChain::Add`](https://root.cern.ch/doc/master/classTChain.html).
   std::vector<ComPWA::Event> readData(const std::string &InputFilePath) const;
 
   void writeData(const std::vector<ComPWA::Event> &Events,

--- a/Examples/SimFit/SimFit.cpp
+++ b/Examples/SimFit/SimFit.cpp
@@ -226,7 +226,7 @@ energyPar createEnergyPar(size_t NEvents, double SqrtS, int seed,
 
 ///
 /// Simulaneous fit of multiple energy points of the reaction
-/// e+e- \to pi+ pi - J/psi.
+/// \f$ e^+e^- \to pi^+ pi^- J/psi \f$.
 ///
 int main(int argc, char **argv) {
   using namespace ComPWA;

--- a/Physics/Dynamics/Flatte.hpp
+++ b/Physics/Dynamics/Flatte.hpp
@@ -89,10 +89,10 @@ dynamicalFunction(double mSq, double mR, double gA, std::complex<double> termA,
  * @param gA coupling constant for signal channel
  * @param massB1 mass of first particle of second channel
  * @param massB2 mass of second particle of second channel
- * @param gB coupling constant for second channel
+ * @param couplingB coupling constant for second channel
  * @param massC1 mass of first particle of third channel
  * @param massC2 mass of third particle of third channel
- * @param gC coupling constant for third channel
+ * @param couplingC coupling constant for third channel
  * @param L Orbital angular momentum between two daughters a and b
  * @param mesonRadius 1/interaction length (needed for barrier factors)
  * @param ffType formfactor type

--- a/Physics/Dynamics/Voigtian.hpp
+++ b/Physics/Dynamics/Voigtian.hpp
@@ -25,15 +25,16 @@ namespace Dynamics {
 ///
 /// \namespace Voigtian
 /// Voigtian is the convolution of a non-relativisitc Breit-Wigner
-/// with a Gaussian.
-/// ref: https://en.wikipedia.org/wiki/Voigt_profile
-///      Voig(x; sigma, gamma) = \int Gaus(x';\sigma)BW(x - x';gamma) dx'
+/// with a Gaussian, see
+/// [Wikipedia](https://en.wikipedia.org/wiki/Voigt_profile) \f[
+///      \mathrm{Voig}(x; \sigma, \gamma) = \int Gaus(x';\sigma)BW(x - x';gamma)
+///      dx'
 ///                            = Re[w(z)]/(\sigma\sqrt{2\pi})
 ///                              and z = (x + i\gamma)/(\sigma\sqrt{s})
-/// In the calculation of voigt function, a Faddeeva Package is used to
-/// calculate w(z). ref:
-/// http://ab-initio.mit.edu/wiki/index.php/Faddeeva_Package
-///      this page is a package for computation of w(z)
+/// \f]
+/// In the calculation of voigt function, a [Faddeeva
+/// Package](http://ab-initio.mit.edu/wiki/index.php/Faddeeva_Package) this page
+/// is a package for computation of w(z)) is used to calculate w(z).
 ///
 namespace Voigtian {
 

--- a/Physics/PhspVolume.cpp
+++ b/Physics/PhspVolume.cpp
@@ -49,7 +49,7 @@ std::pair<double, double> PhspVolume(double s, std::vector<double> &masses,
       auto sample =
           IntegrationSample(s_range.first, s_range.second, SampleSize + 1);
       // * Create profile vector of phasespace for N - 1 particles
-      /// @TODO: Better to reuse this sample per recursion. Now it is
+      /// @todo Better to reuse this sample per recursion. Now it is
       /// regenerated for each iteration.
       std::vector<double> previousPhsp(sample.size() - 1);
       auto masses_new = masses;

--- a/Physics/PhspVolume.hpp
+++ b/Physics/PhspVolume.hpp
@@ -21,8 +21,8 @@ namespace Physics {
 /// particles in the final state using Riemann integration.
 /// @return A pair: first value is the volume, second is the error (currently
 /// set to `0.`)
-/// @TODO Implement errors (second member of the pair).
-/// @TODO Algorithm might be improved with [Simpson's
+/// @todo Implement errors (second member of the pair).
+/// @todo Algorithm might be improved with [Simpson's
 /// rule](https://en.wikipedia.org/wiki/Simpson%27s_rule), because we integrate
 /// over a function that is polynomial in the limit \f$m_i\rightarrow 0\f$
 std::pair<double, double> PhspVolume(double s, std::vector<double> &FSMasses,

--- a/Tools/Integration.hpp
+++ b/Tools/Integration.hpp
@@ -32,10 +32,11 @@ namespace Tools {
 /// (f(\overline{\mathbf{x}}_i) - \langle f \rangle \right )^2
 /// \f]
 /// We use a Kahan summation to improve numerical stability. We return
-/// $\sqrt{\mathrm{Var}(Q_N)}$ as error.
-std::pair<double, double> integrateWithError(ComPWA::Intensity &intensity,
-                 const ComPWA::Data::DataSet &phspsample,
-                 double phspVolume = 1.0);
+/// \f$ \sqrt{\mathrm{Var}(Q_N)} \f$ as error.
+std::pair<double, double>
+integrateWithError(ComPWA::Intensity &intensity,
+                   const ComPWA::Data::DataSet &phspsample,
+                   double phspVolume = 1.0);
 
 double integrate(ComPWA::Intensity &intensity,
                  const ComPWA::Data::DataSet &phspsample,

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,6 +1,7 @@
-xml
-build
+build/
+html/
 source/cpp
 source/examples
 source/expertsystem
 source/plotting
+xml

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -51,7 +51,7 @@ PROJECT_BRIEF          = "Common Partial-Wave-Analysis Framework"
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           =
+# PROJECT_LOGO           = doc/imaGges/logo-small.png
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
@@ -714,7 +714,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES
@@ -752,7 +752,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -781,6 +781,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = ./
+INPUT                 += doc/main.md
+USE_MDFILE_AS_MAINPAGE = doc/main.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -810,6 +812,7 @@ FILE_PATTERNS          = *.h \
                          *.hpp \
                          *.hxx \
                          *.h++ \
+                         *.C \
                          *.c \
                          *.cc \
                          *.cpp \
@@ -1415,7 +1418,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 
 # The ENUM_VALUES_PER_LINE tag can be used to set the number of enum values that
 # doxygen will group on one line in the generated HTML documentation.

--- a/doc/main.md
+++ b/doc/main.md
@@ -1,0 +1,8 @@
+Common Partial-Wave-Analysis Framework (%ComPWA) {#mainpage}
+===========================================================
+
+Welcome to the class documentation of ComPWA!
+
+These pages are particularly useful if you are working on the C++ backend of the %ComPWA framework. See [here](https://github.com/ComPWA/ComPWA) for the source code.
+
+If you want to use the %ComPWA framework to do partial wave analysis, you can read [here](https://pycompwa.readthedocs.io/en/latest/) how to use [pycompwa](https://github.com/ComPWA/pycompwa), the Python interface of %ComPWA.


### PR DESCRIPTION
The [`Doxyfile`](https://github.com/ComPWA/ComPWA/pull/247/files#diff-68ad3c5bb145baa269fae12dc5404459) has undergone some changes: the eventual class documentation now has a tree view and generates a todo list.

A warning though: the Doxyfile is also more strict now, because warnings are treated as errors, so that Travis CI will fail if you make syntax errors. The syntax errors in existing comments have therefore also been fixed.

Note that the QUIET flag has been set, so that it will be easier to spot possible mistakes in the output of Travis CI.