### PR TITLE
readParticles overload for ptree

### DIFF
--- a/Core/Properties.cpp
+++ b/Core/Properties.cpp
@@ -151,16 +151,16 @@ void insertParticles(ParticleList &list, std::string FileName) {
 ParticleList readParticles(std::stringstream &Stream) {
   boost::property_tree::ptree tree;
   boost::property_tree::xml_parser::read_xml(Stream, tree);
-
-  ParticleList list;
-  insertParticles(list, tree);
-  return list;
+  return readParticles(tree);
 }
 
 ParticleList readParticles(std::string FileName) {
   boost::property_tree::ptree tree;
   boost::property_tree::xml_parser::read_xml(FileName, tree);
+  return readParticles(tree);
+}
 
+ParticleList readParticles(boost::property_tree::ptree &tree) {
   ParticleList list;
   insertParticles(list, tree);
   return list;

--- a/Core/Properties.hpp
+++ b/Core/Properties.hpp
@@ -131,6 +131,9 @@ ParticleList readParticles(std::stringstream &Stream);
 /// Read list of particles from a xml file
 ParticleList readParticles(std::string FileName);
 
+/// Read list of particles from a `boost::property_tree::ptree`
+ParticleList readParticles(boost::property_tree::ptree &pt);
+
 } // namespace ComPWA
 
 #endif


### PR DESCRIPTION
Small changes:
* Clang-format now aligns assignment statements
* In order to make the C++ example files a bit more consistent, `readParticles` now takes a boost `ptree`, just like `createHelicityKinematics` and `IntensityBuilderXML`.