### PR TITLE
DataSet, Intensity and Helicity kinematics rework 

### DIFF
--- a/Core/Event.cpp
+++ b/Core/Event.cpp
@@ -36,17 +36,4 @@ double getMaximumSampleWeight(const std::vector<Event> &sample) {
   return MaxWeight;
 }
 
-std::ostream &operator<<(std::ostream &os, const DataPoint &p) {
-  os << "(";
-  for (unsigned int i = 0; i < p.KinematicVariableList.size(); ++i) {
-    os << p.KinematicVariableList[i];
-    if (i != p.KinematicVariableList.size() - 1) {
-      os << ", ";
-    }
-  }
-  os << ")";
-
-  return os;
-}
-
 } // namespace ComPWA

--- a/Core/Event.hpp
+++ b/Core/Event.hpp
@@ -26,19 +26,6 @@ double calculateInvariantMass(const Event &ev);
 
 double getMaximumSampleWeight(const std::vector<Event> &sample);
 
-///
-/// Data structure which contains a reduced set of the kinematic information of
-/// an Event. Only the variables that are needed to evaluate a specific
-/// Intensity are stored. In case of the HelicityFormalism is would be a triple
-/// \f$(s,\theta,\phi)\f$ for each occurring SubSystem.
-///
-struct DataPoint {
-  std::vector<double> KinematicVariableList;
-  double Weight = 1.0;
-};
-
-std::ostream &operator<<(std::ostream &os, const DataPoint &p);
-
 } // namespace ComPWA
 
 #endif

--- a/Core/Function.hpp
+++ b/Core/Function.hpp
@@ -2,6 +2,7 @@
 #define CORE_FUNCTION_HPP_
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace ComPWA {
@@ -10,6 +11,8 @@ struct Parameter {
   std::string Name;
   double Value;
 };
+
+using DataMap = std::unordered_map<std::string, std::vector<double>>;
 
 /// Interface template for a general Function of the form
 /// OutputType Function(InputTypes)
@@ -34,8 +37,7 @@ public:
 
 /// An Intensity is just a Function that takes a list of data vectors and
 /// returns a list of intensities (double)
-using Intensity =
-    Function<std::vector<double>, std::vector<std::vector<double>>>;
+using Intensity = Function<std::vector<double>, DataMap>;
 
 } // namespace ComPWA
 

--- a/Core/FunctionTree/FunctionTreeIntensity.cpp
+++ b/Core/FunctionTree/FunctionTreeIntensity.cpp
@@ -1,7 +1,7 @@
 #include "Core/FunctionTree/FunctionTreeIntensity.hpp"
 #include "Core/FunctionTree/TreeNode.hpp"
 #include "Core/FunctionTree/Value.hpp"
-#include "Core/Kinematics.hpp"
+#include "Data/DataSet.hpp"
 
 namespace ComPWA {
 namespace FunctionTree {
@@ -12,16 +12,15 @@ FunctionTreeIntensity::FunctionTreeIntensity(std::shared_ptr<TreeNode> Tree_,
   Tree->parameter();
 }
 
-std::vector<double> FunctionTreeIntensity::evaluate(
-    const std::vector<std::vector<double>> &data) noexcept {
+std::vector<double>
+FunctionTreeIntensity::evaluate(const ComPWA::DataMap &data) noexcept {
   updateDataContainers(data);
   auto val =
       std::dynamic_pointer_cast<Value<std::vector<double>>>(Tree->parameter());
   return val->value();
 }
 
-void FunctionTreeIntensity::updateDataContainers(
-    const std::vector<std::vector<double>> &data) {
+void FunctionTreeIntensity::updateDataContainers(const ComPWA::DataMap &data) {
   ComPWA::FunctionTree::updateDataContainers(Data, data);
 }
 
@@ -44,7 +43,7 @@ std::vector<ComPWA::Parameter> FunctionTreeIntensity::getParameters() const {
 
 std::tuple<std::shared_ptr<ComPWA::FunctionTree::TreeNode>,
            ComPWA::FunctionTree::ParameterList>
-FunctionTreeIntensity::bind(const std::vector<std::vector<double>> &data) {
+FunctionTreeIntensity::bind(const ComPWA::DataMap &data) {
   updateDataContainers(data);
   return std::make_tuple(Tree, Parameters);
 }
@@ -53,8 +52,7 @@ std::string FunctionTreeIntensity::print(int level) const {
   return Tree->print(level);
 }
 
-void updateDataContainers(ParameterList Data,
-                          const std::vector<std::vector<double>> &data) {
+void updateDataContainers(ParameterList Data, const ComPWA::DataMap &data) {
   // just loop over the vectors and fill in the data
   if (Data.mDoubleValues().size() > data.size()) {
     std::stringstream ss;
@@ -64,7 +62,7 @@ void updateDataContainers(ParameterList Data,
     throw std::out_of_range(ss.str());
   }
   for (size_t i = 0; i < Data.mDoubleValues().size(); ++i) {
-    Data.mDoubleValue(i)->setValue(data[i]);
+    Data.mDoubleValue(i)->setValue(data.at(Data.mDoubleValue(i)->name()));
   }
 }
 

--- a/Core/FunctionTree/FunctionTreeIntensity.hpp
+++ b/Core/FunctionTree/FunctionTreeIntensity.hpp
@@ -5,10 +5,11 @@
 
 #include "Core/Function.hpp"
 #include "Core/FunctionTree/ParameterList.hpp"
-#include "FunctionTreeEstimator.hpp"
 
 namespace ComPWA {
-class Kinematics;
+namespace Data {
+struct DataMap;
+}
 namespace FunctionTree {
 class TreeNode;
 
@@ -21,28 +22,26 @@ public:
 
   FunctionTreeIntensity(FunctionTreeIntensity &&other) = default;
 
-  std::vector<double>
-  evaluate(const std::vector<std::vector<double>> &data) noexcept;
+  std::vector<double> evaluate(const ComPWA::DataMap &data) noexcept;
 
   void updateParametersFrom(const std::vector<double> &params);
   std::vector<ComPWA::Parameter> getParameters() const;
 
   std::tuple<std::shared_ptr<ComPWA::FunctionTree::TreeNode>,
              ComPWA::FunctionTree::ParameterList>
-  bind(const std::vector<std::vector<double>> &data);
+  bind(const ComPWA::DataMap &data);
 
   std::string print(int level) const;
 
 private:
-  void updateDataContainers(const std::vector<std::vector<double>> &data);
+  void updateDataContainers(const ComPWA::DataMap &data);
 
   std::shared_ptr<TreeNode> Tree;
   ParameterList Parameters;
   ParameterList Data;
 };
 
-void updateDataContainers(ParameterList Data,
-                          const std::vector<std::vector<double>> &data);
+void updateDataContainers(ParameterList Data, const ComPWA::DataMap &data);
 
 } // namespace FunctionTree
 } // namespace ComPWA

--- a/Core/FunctionTree/ParameterList.cpp
+++ b/Core/FunctionTree/ParameterList.cpp
@@ -20,7 +20,7 @@ namespace FunctionTree {
 ParameterList::ParameterList(const ComPWA::Data::DataSet &DataSample) {
   // Add data vector to ParameterList
   for (auto x : DataSample.Data)
-    addValue(MDouble("", x));
+    addValue(MDouble(x.first, x.second));
   // Adding weight at the end
   addValue(MDouble("Weight", DataSample.Weights));
 }
@@ -94,9 +94,7 @@ void ParameterList::addParameter(std::shared_ptr<Parameter> par) {
     addParameter(std::dynamic_pointer_cast<FunctionTree::FitParameter>(par));
     break;
   }
-  default: {
-    break;
-  }
+  default: { break; }
   }
 }
 
@@ -141,9 +139,7 @@ void ParameterList::addValue(std::shared_ptr<Parameter> par) {
             par));
     break;
   }
-  default: {
-    break;
-  }
+  default: { break; }
   }
 }
 

--- a/Core/Kinematics.hpp
+++ b/Core/Kinematics.hpp
@@ -10,8 +10,11 @@
 
 namespace ComPWA {
 
-struct DataPoint;
 struct Event;
+
+namespace Data {
+struct DataSet;
+}
 
 /// The Kinematics interface is responsible for converting an Event into a
 /// DataPoint.
@@ -19,12 +22,12 @@ class Kinematics {
 public:
   virtual ~Kinematics() = default;
 
-  virtual DataPoint convert(const ComPWA::Event &event) const = 0;
-
-  virtual std::vector<std::string> getKinematicVariableNames() const = 0;
+  virtual ComPWA::Data::DataSet
+  convert(const std::vector<ComPWA::Event> &Events) const = 0;
 
   /// checks if DataPoint is within phase space boundaries
-  virtual bool isWithinPhaseSpace(const DataPoint &point) const = 0;
+  virtual std::vector<ComPWA::Event>
+  reduceToPhaseSpace(const std::vector<ComPWA::Event> &Events) const = 0;
 
   virtual double phspVolume() const = 0;
 };

--- a/Data/DataSet.hpp
+++ b/Data/DataSet.hpp
@@ -6,7 +6,6 @@
 #define DATA_DATASET_HPP_
 
 #include <memory>
-#include <vector>
 
 #include "Core/Event.hpp"
 #include "Core/Function.hpp"
@@ -15,35 +14,22 @@ namespace ComPWA {
 class Kinematics;
 namespace Data {
 
-using DataList = std::vector<std::vector<double>>;
-
 struct DataSet {
-  DataList Data;
+  ComPWA::DataMap Data;
   std::vector<double> Weights;
-  std::vector<std::string> VariableNames;
 };
 
 inline void resize(DataSet &set, size_t size) {
   set.Weights.resize(size);
   for (auto &i : set.Data) {
-    i.resize(size);
+    i.second.resize(size);
   }
 }
-
-std::vector<Event> reduceToPhaseSpace(const std::vector<Event> &Events,
-                                      const ComPWA::Kinematics &Kinematics);
 
 std::vector<Event>
 addIntensityWeights(std::shared_ptr<ComPWA::Intensity> Intensity,
                     const std::vector<Event> &Events,
                     const ComPWA::Kinematics &Kinematics);
-
-DataSet convertEventsToDataSet(std::vector<Event>::const_iterator EventsBegin,
-                               std::vector<Event>::const_iterator EventsEnd,
-                               const ComPWA::Kinematics &Kinematics);
-
-DataSet convertEventsToDataSet(const std::vector<Event> &Events,
-                               const ComPWA::Kinematics &Kinematics);
 
 } // namespace Data
 } // namespace ComPWA

--- a/Data/Generate.cpp
+++ b/Data/Generate.cpp
@@ -26,9 +26,8 @@ generateBunch(unsigned int EventBunchSize, const ComPWA::Kinematics &Kinematics,
 
   std::vector<ComPWA::Event> SelectedEvents;
 
-  auto TempDataSet = ComPWA::Data::convertEventsToDataSet(
-      PhspTrueStartIterator, PhspTrueStartIterator + EventBunchSize,
-      Kinematics);
+  auto TempDataSet = Kinematics.convert(std::vector<Event>(
+      PhspTrueStartIterator, PhspTrueStartIterator + EventBunchSize));
 
   // evaluate the intensity
   auto Intensities = Intensity.evaluate(TempDataSet.Data);

--- a/Data/Root/RootEfficiency.cpp
+++ b/Data/Root/RootEfficiency.cpp
@@ -3,11 +3,11 @@
 // https://github.com/ComPWA/ComPWA/license.txt for details.
 
 #include "Data/Root/RootEfficiency.hpp"
-
-#include "TH2.h"
-
 #include "Core/Event.hpp"
 #include "Core/Exceptions.hpp"
+#include "Data/DataSet.hpp"
+
+#include "TH2.h"
 
 namespace ComPWA {
 namespace Data {
@@ -24,28 +24,19 @@ RootEfficiency::RootEfficiency(TH1 *passed, TH1 *total)
   LOG(DEBUG) << "RootEfficiency: creating efficiency from two TH2D objects!";
 }
 
-RootEfficiency::RootEfficiency(const RootEfficiency &) {}
-
-double RootEfficiency::evaluate(const DataPoint &point) const {
-  //	double m13sq = point.getVal("m13sq");
-  //	double m23sq = point.getVal("m23sq");
-  double m13sq = point.KinematicVariableList[1];
-  double m23sq = point.KinematicVariableList[0];
-
-  TH2D *test = (TH2D *)effHist->GetPassedHistogram();
-  int globalBin = test->FindBin(m23sq, m13sq);
-  return effHist->GetEfficiency(globalBin);
+std::vector<double> RootEfficiency::evaluate(const DataSet &dataset) const {
+  throw std::runtime_error(
+      "RootEfficiency::evaluate(): is currently not implemented!");
+  return {};
 }
 
 // ------------------ ROOTANGLEEFFICIENCY ---------------------
 
-double RootAngleEfficiency::evaluate(const DataPoint &point) const {
-  double m23sq = point.KinematicVariableList[0];
-  double angle = point.KinematicVariableList[8];
-
-  TH2D *test = (TH2D *)effHist->GetPassedHistogram();
-  int globalBin = test->FindBin(m23sq, angle);
-  return effHist->GetEfficiency(globalBin);
+std::vector<double>
+RootAngleEfficiency::evaluate(const DataSet &dataset) const {
+  throw std::runtime_error(
+      "RootAngleEfficiency::evaluate(): is currently not implemented!");
+  return {};
 }
 
 } // namespace Root

--- a/Data/Root/RootEfficiency.hpp
+++ b/Data/Root/RootEfficiency.hpp
@@ -8,14 +8,16 @@
 #include <memory>
 #include <vector>
 
-#include <TEfficiency.h>
-
 #include "Core/Efficiency.hpp"
+
+#include <TEfficiency.h>
 
 class TH1;
 
 namespace ComPWA {
 namespace Data {
+struct DataSet;
+
 namespace Root {
 
 /**
@@ -32,11 +34,9 @@ public:
   //! Construct RootEfficiency from two TH2 objects for passed and total
   //! events
   RootEfficiency(TH1 *passed, TH1 *total);
-  RootEfficiency(const RootEfficiency &);
-  ~RootEfficiency(){};
+  ~RootEfficiency() = default;
 
-  //! returns efficiency for current datapoint
-  virtual double evaluate(const DataPoint &point) const;
+  virtual std::vector<double> evaluate(const DataSet &dataset) const;
 };
 
 /**
@@ -55,11 +55,9 @@ public:
   RootAngleEfficiency(TH1 *passed, TH1 *total)
       : RootEfficiency(passed, total){};
 
-  RootAngleEfficiency(const RootAngleEfficiency &p) : RootEfficiency(p){};
+  ~RootAngleEfficiency() = default;
 
-  ~RootAngleEfficiency(){};
-
-  virtual double evaluate(const DataPoint &point) const;
+  virtual std::vector<double> evaluate(const DataSet &dataset) const;
 };
 
 } // namespace Root

--- a/Estimator/test/MinLogLHEstimatorTest.cpp
+++ b/Estimator/test/MinLogLHEstimatorTest.cpp
@@ -26,9 +26,8 @@ public:
         Width(ComPWA::Parameter{"width", width}),
         Strength(ComPWA::Parameter{"strength", 1.0}) {}
 
-  std::vector<double>
-  evaluate(const std::vector<std::vector<double>> &data) noexcept {
-    auto const &xvals = data[0];
+  std::vector<double> evaluate(const ComPWA::DataMap &data) noexcept {
+    auto const &xvals = data.at("x");
     std::vector<double> result(xvals.size());
     std::transform(xvals.begin(), xvals.end(), result.begin(), [&](double x) {
       return Strength.Value * std::exp(-0.5 * std::pow(x - Mean.Value, 2) /
@@ -155,7 +154,7 @@ BOOST_AUTO_TEST_CASE(MinLogLHEstimator_GaussianModelFitTest) {
                                          mean + 10.0 * sigma);
 
   ComPWA::Data::DataSet PhspSample;
-  PhspSample.Data.push_back({});
+  PhspSample.Data.insert(std::make_pair("x", std::vector<double>()));
   std::mt19937 mt_gen(123456);
 
   std::uniform_real_distribution<double> distribution(domain_range.first,
@@ -163,7 +162,7 @@ BOOST_AUTO_TEST_CASE(MinLogLHEstimator_GaussianModelFitTest) {
   // a sample size of 20000 is necessary to have a good normalization
   // and precise fit parameters
   for (unsigned int i = 0; i < 20000; ++i) {
-    PhspSample.Data[0].push_back(distribution(mt_gen));
+    PhspSample.Data["x"].push_back(distribution(mt_gen));
     PhspSample.Weights.push_back(1.0);
   }
 
@@ -173,7 +172,7 @@ BOOST_AUTO_TEST_CASE(MinLogLHEstimator_GaussianModelFitTest) {
   std::normal_distribution<double> normal_distribution(mean, sigma);
 
   ComPWA::Data::DataSet DataSample;
-  DataSample.Data.push_back({});
+  DataSample.Data.insert(std::make_pair("x", std::vector<double>()));
   DataSample.Weights = std::vector<double>(500, 1.0);
   std::chrono::milliseconds MeanFittime(0);
   std::chrono::milliseconds MeanFittimeFT(0);
@@ -184,9 +183,9 @@ BOOST_AUTO_TEST_CASE(MinLogLHEstimator_GaussianModelFitTest) {
 
   unsigned int NumSamples(50);
   for (unsigned i = 0; i < NumSamples; ++i) {
-    DataSample.Data[0].clear();
+    DataSample.Data["x"].clear();
     for (unsigned int j = 0; j < 500; ++j) {
-      DataSample.Data[0].push_back(normal_distribution(mt_gen));
+      DataSample.Data["x"].push_back(normal_distribution(mt_gen));
     }
 
     double startmean(start_distribution(mt_gen) * mean);
@@ -323,7 +322,7 @@ BOOST_AUTO_TEST_CASE(MinLogLHEstimator_GaussianModelEventWeightTest) {
                                          mean + 10.0 * sigma);
 
   ComPWA::Data::DataSet PhspSample;
-  PhspSample.Data.push_back({});
+  PhspSample.Data.insert(std::make_pair("x", std::vector<double>()));
   std::mt19937 mt_gen(123456);
 
   std::uniform_real_distribution<double> distribution(domain_range.first,
@@ -331,7 +330,7 @@ BOOST_AUTO_TEST_CASE(MinLogLHEstimator_GaussianModelEventWeightTest) {
   // a sample size of 20000 is necessary to have a good normalization
   // and precise fit parameters
   for (unsigned int i = 0; i < 20000; ++i) {
-    PhspSample.Data[0].push_back(distribution(mt_gen));
+    PhspSample.Data["x"].push_back(distribution(mt_gen));
     PhspSample.Weights.push_back(1.0);
   }
 
@@ -357,7 +356,7 @@ BOOST_AUTO_TEST_CASE(MinLogLHEstimator_GaussianModelEventWeightTest) {
   std::uniform_real_distribution<double> data_distribution(mean - 5.0 * sigma,
                                                            mean + 5.0 * sigma);
   ComPWA::Data::DataSet DataSample;
-  DataSample.Data.push_back({});
+  DataSample.Data.insert(std::make_pair("x", std::vector<double>()));
   std::chrono::milliseconds MeanFittime(0);
   std::chrono::milliseconds MeanFittimeFT(0);
   std::vector<std::pair<double, double>> MeanFitValues;
@@ -370,11 +369,11 @@ BOOST_AUTO_TEST_CASE(MinLogLHEstimator_GaussianModelEventWeightTest) {
     // reset the parameters, so that the weights are determined correctly
     Gauss.updateParametersFrom({mean, sigma, 1.0 / integral});
 
-    DataSample.Data[0].clear();
+    DataSample.Data["x"].clear();
     DataSample.Weights.clear();
     unsigned int SampleSize(500);
     for (unsigned int j = 0; j < SampleSize; ++j) {
-      DataSample.Data[0].push_back(data_distribution(mt_gen));
+      DataSample.Data["x"].push_back(data_distribution(mt_gen));
     }
     auto TempIntensities = Gauss.evaluate(DataSample.Data);
     double WeightSum(

--- a/Examples/DalitzFit/DalitzFitApp.cpp
+++ b/Examples/DalitzFit/DalitzFitApp.cpp
@@ -275,7 +275,7 @@ int main(int argc, char **argv) {
   auto sample =
       ComPWA::Data::generate(1000, kin, RandomGenerator, intens, phspSample);
 
-  auto SampleDataSet = Data::convertEventsToDataSet(sample, kin);
+  auto SampleDataSet = kin.convert(sample);
   //---------------------------------------------------
   // 5) Fit the model to the data and print the result
   //---------------------------------------------------
@@ -300,7 +300,7 @@ int main(int argc, char **argv) {
 
   ComPWA::Tools::FitFractions FF;
   auto FitFractionList = FF.calculateFitFractionsWithCovarianceErrorPropagation(
-      MyFractions, Data::convertEventsToDataSet(phspSample, kin), result);
+      MyFractions, kin.convert(phspSample), result);
 
   LOG(INFO) << FitFractionList;
 

--- a/Examples/SimFit/SimFit.cpp
+++ b/Examples/SimFit/SimFit.cpp
@@ -219,7 +219,7 @@ energyPar createEnergyPar(size_t NEvents, double SqrtS, int seed,
 
   auto data =
       ComPWA::Data::generate(NEvents, kin, RandomGenerator, amp, mcSample);
-  auto dataSet = ComPWA::Data::convertEventsToDataSet(data, kin);
+  auto dataSet = kin.convert(data);
   return energyPar{NEvents, std::move(kin), std::move(amp),
                    data,    mcSample,       dataSet};
 }
@@ -311,21 +311,17 @@ int main(int argc, char **argv) {
       sqrtS4230.Kinematics.getParticleStateTransitionKinematicsInfo(),
       "plot.root", "RECREATE");
   sqrtS4230_pl.createDirectory("sqrtS4230");
-  sqrtS4230_pl.writeData(
-      Data::convertEventsToDataSet(sqrtS4230.DataSample, sqrtS4230.Kinematics));
+  sqrtS4230_pl.writeData(sqrtS4230.Kinematics.convert(sqrtS4230.DataSample));
   sqrtS4230_pl.writeIntensityWeightedPhspSample(
-      Data::convertEventsToDataSet(sqrtS4230.McSample, sqrtS4230.Kinematics),
-      sqrtS4230.Intens);
+      sqrtS4230.Kinematics.convert(sqrtS4230.McSample), sqrtS4230.Intens);
 
   ComPWA::Tools::Plotting::RootPlotData sqrtS4260_pl(
       sqrtS4260.Kinematics.getParticleStateTransitionKinematicsInfo(),
       "plot.root", "UPDATE");
   sqrtS4260_pl.createDirectory("sqrtS4230");
-  sqrtS4260_pl.writeData(
-      Data::convertEventsToDataSet(sqrtS4260.DataSample, sqrtS4260.Kinematics));
+  sqrtS4260_pl.writeData(sqrtS4260.Kinematics.convert(sqrtS4260.DataSample));
   sqrtS4260_pl.writeIntensityWeightedPhspSample(
-      Data::convertEventsToDataSet(sqrtS4260.McSample, sqrtS4260.Kinematics),
-      sqrtS4260.Intens);
+      sqrtS4260.Kinematics.convert(sqrtS4260.McSample), sqrtS4260.Intens);
 
   LOG(INFO) << "Done";
 

--- a/Examples/test/FitTest/CMakeLists.txt
+++ b/Examples/test/FitTest/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable( ${testName} ${testSrc} )
 
 # Link to Boost libraries AND your targets and dependencies
 target_link_libraries( ${testName}
-  PRIVATE Core Minuit2IF MinLogLH RootData Integration HelicityFormalism Plotting
+  PRIVATE Core Minuit2IF MinLogLH RootData Integration HelicityFormalism
   Boost::unit_test_framework
 )
 

--- a/Examples/test/FitTest/FitTest.cpp
+++ b/Examples/test/FitTest/FitTest.cpp
@@ -228,8 +228,8 @@ BOOST_AUTO_TEST_CASE(HelicityDalitzFit) {
   auto sample =
       ComPWA::Data::generate(1000, kin, RandomGenerator, intens, phspSample);
 
-  auto PhspSampleDataSet = Data::convertEventsToDataSet(phspSample, kin);
-  auto SampleDataSet = Data::convertEventsToDataSet(sample, kin);
+  auto PhspSampleDataSet = kin.convert(phspSample);
+  auto SampleDataSet = kin.convert(sample);
 
   //---------------------------------------------------
   // 5) Fit the model to the data and print the result

--- a/Physics/Dynamics/Flatte.cpp
+++ b/Physics/Dynamics/Flatte.cpp
@@ -15,9 +15,9 @@ using ComPWA::FunctionTree::TreeNode;
 using ComPWA::FunctionTree::Value;
 
 std::shared_ptr<TreeNode> Flatte::createFunctionTree(
-    InputInfo Params, const ComPWA::FunctionTree::ParameterList &DataSample,
-    unsigned int pos) {
-
+    InputInfo Params,
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>>
+        InvMassSquared) {
   if (Params.HiddenCouplings.size() == 1)
     Params.HiddenCouplings.push_back(Coupling(0.0, 0.0, 0.0));
 
@@ -30,7 +30,7 @@ std::shared_ptr<TreeNode> Flatte::createFunctionTree(
     throw std::runtime_error(
         "Flatte::createFunctionTree() | Coupling to signal channel not set");
 
-  size_t sampleSize = DataSample.mDoubleValue(pos)->values().size();
+  size_t sampleSize = InvMassSquared->values().size();
 
   using namespace ComPWA::FunctionTree;
   auto tr = std::make_shared<TreeNode>(MComplex("", sampleSize),
@@ -44,9 +44,10 @@ std::shared_ptr<TreeNode> Flatte::createFunctionTree(
                   createLeaf(Params.HiddenCouplings.at(i).MassB),
                   createLeaf(Params.HiddenCouplings.at(i).G)});
   }
-  tr->addNodes({createLeaf((double)Params.L, "L"), createLeaf(Params.MesonRadius),
+  tr->addNodes({createLeaf((double)Params.L, "L"),
+                createLeaf(Params.MesonRadius),
                 createLeaf((double)Params.FFType, "FormFactorType"),
-                createLeaf(DataSample.mDoubleValue(pos))});
+                createLeaf(InvMassSquared)});
 
   return tr;
 }

--- a/Physics/Dynamics/Flatte.hpp
+++ b/Physics/Dynamics/Flatte.hpp
@@ -122,19 +122,18 @@ dynamicalFunction(double mSq, double mR, double massA1, double massA2,
   return dynamicalFunction(mSq, mR, gA, termA, termB, termC);
 }
 
-std::shared_ptr<ComPWA::FunctionTree::TreeNode>
-createFunctionTree(InputInfo Params,
-                   const ComPWA::FunctionTree::ParameterList &DataSample,
-                   unsigned int pos);
+std::shared_ptr<ComPWA::FunctionTree::TreeNode> createFunctionTree(
+    InputInfo Params,
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>>
+        InvMassSquared);
 
 } // namespace Flatte
 
 class FlatteStrategy : public ComPWA::FunctionTree::Strategy {
 public:
   FlatteStrategy(std::string resonanceName)
-      : Strategy(ComPWA::FunctionTree::ParType::MCOMPLEX, "Flatte") {
-  }
-  
+      : Strategy(ComPWA::FunctionTree::ParType::MCOMPLEX, "Flatte") {}
+
   virtual void execute(ComPWA::FunctionTree::ParameterList &paras,
                        std::shared_ptr<ComPWA::FunctionTree::Parameter> &out);
 };

--- a/Physics/Dynamics/FormFactor.cpp
+++ b/Physics/Dynamics/FormFactor.cpp
@@ -18,9 +18,10 @@ std::shared_ptr<ComPWA::FunctionTree::TreeNode> createFunctionTree(
     std::shared_ptr<ComPWA::FunctionTree::FitParameter> Daughter1Mass,
     std::shared_ptr<ComPWA::FunctionTree::FitParameter> Daughter2Mass,
     std::shared_ptr<ComPWA::FunctionTree::FitParameter> MesonRadius,
-    unsigned int L, FormFactorType FFType, const ParameterList &DataSample,
-    unsigned int pos) {
-  size_t sampleSize = DataSample.mDoubleValue(0)->values().size();
+    unsigned int L, FormFactorType FFType,
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>>
+        InvMassSquared) {
+  size_t sampleSize = InvMassSquared->values().size();
 
   auto ffTree =
       std::make_shared<TreeNode>(ComPWA::FunctionTree::MDouble("", sampleSize),
@@ -31,7 +32,7 @@ std::shared_ptr<ComPWA::FunctionTree::TreeNode> createFunctionTree(
                     FunctionTree::createLeaf((int)FFType, "FormFactorType"),
                     FunctionTree::createLeaf(Daughter1Mass),
                     FunctionTree::createLeaf(Daughter2Mass),
-                    FunctionTree::createLeaf(DataSample.mDoubleValue(pos))});
+                    FunctionTree::createLeaf(InvMassSquared)});
   ffTree->parameter();
 
   return ffTree;

--- a/Physics/Dynamics/FormFactor.hpp
+++ b/Physics/Dynamics/FormFactor.hpp
@@ -179,7 +179,8 @@ std::shared_ptr<ComPWA::FunctionTree::TreeNode> createFunctionTree(
     std::shared_ptr<ComPWA::FunctionTree::FitParameter> Daughter2Mass,
     std::shared_ptr<ComPWA::FunctionTree::FitParameter> MesonRadius,
     unsigned int L, FormFactorType FFType,
-    const ComPWA::FunctionTree::ParameterList &DataSample, unsigned int pos);
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>>
+        InvMassSquared);
 
 class FormFactorStrategy : public ComPWA::FunctionTree::Strategy {
 public:

--- a/Physics/Dynamics/RelativisticBreitWigner.cpp
+++ b/Physics/Dynamics/RelativisticBreitWigner.cpp
@@ -15,9 +15,10 @@ using ComPWA::FunctionTree::TreeNode;
 using ComPWA::FunctionTree::Value;
 
 std::shared_ptr<TreeNode> RelativisticBreitWigner::createFunctionTree(
-    RelativisticBreitWigner::InputInfo Params, const ParameterList &DataSample,
-    unsigned int pos) {
-  size_t sampleSize = DataSample.mDoubleValue(pos)->values().size();
+    RelativisticBreitWigner::InputInfo Params,
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>>
+        InvMassSquared) {
+  size_t sampleSize = InvMassSquared->values().size();
 
   using namespace ComPWA::FunctionTree;
   auto tr = std::make_shared<TreeNode>(MComplex("", sampleSize),
@@ -28,7 +29,7 @@ std::shared_ptr<TreeNode> RelativisticBreitWigner::createFunctionTree(
                 createLeaf((int)Params.FFType, "FormFactorType"),
                 createLeaf(Params.DaughterMasses.first),
                 createLeaf(Params.DaughterMasses.second),
-                createLeaf(DataSample.mDoubleValue(pos))});
+                createLeaf(InvMassSquared)});
 
   return tr;
 };

--- a/Physics/Dynamics/RelativisticBreitWigner.hpp
+++ b/Physics/Dynamics/RelativisticBreitWigner.hpp
@@ -119,10 +119,10 @@ dynamicalFunction(double mSq, double mR, double ma, double mb, double width,
   return result;
 }
 
-std::shared_ptr<ComPWA::FunctionTree::TreeNode>
-createFunctionTree(InputInfo Params,
-                   const ComPWA::FunctionTree::ParameterList &DataSample,
-                   unsigned int pos);
+std::shared_ptr<ComPWA::FunctionTree::TreeNode> createFunctionTree(
+    InputInfo Params,
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>>
+        InvMassSquared);
 
 } // namespace RelativisticBreitWigner
 

--- a/Physics/Dynamics/Voigtian.cpp
+++ b/Physics/Dynamics/Voigtian.cpp
@@ -15,10 +15,10 @@ using ComPWA::FunctionTree::TreeNode;
 using ComPWA::FunctionTree::Value;
 
 std::shared_ptr<ComPWA::FunctionTree::TreeNode> Voigtian::createFunctionTree(
-    InputInfo Params, const ComPWA::FunctionTree::ParameterList &DataSample,
-    unsigned int pos) {
-
-  size_t sampleSize = DataSample.mDoubleValue(pos)->values().size();
+    InputInfo Params,
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>>
+        InvMassSquared) {
+  size_t sampleSize = InvMassSquared->values().size();
 
   auto tr = std::make_shared<ComPWA::FunctionTree::TreeNode>(
       ComPWA::FunctionTree::MComplex("", sampleSize),
@@ -27,7 +27,7 @@ std::shared_ptr<ComPWA::FunctionTree::TreeNode> Voigtian::createFunctionTree(
   tr->addNodes({FunctionTree::createLeaf(Params.Mass),
                 FunctionTree::createLeaf(Params.Width),
                 FunctionTree::createLeaf(Params.Sigma, "Sigma"),
-                FunctionTree::createLeaf(DataSample.mDoubleValue(pos))});
+                FunctionTree::createLeaf(InvMassSquared)});
 
   return tr;
 };

--- a/Physics/Dynamics/Voigtian.hpp
+++ b/Physics/Dynamics/Voigtian.hpp
@@ -97,10 +97,10 @@ inline std::complex<double> dynamicalFunction(double mSq, double mR, double wR,
   return result;
 }
 
-std::shared_ptr<ComPWA::FunctionTree::TreeNode>
-createFunctionTree(InputInfo Params,
-                   const ComPWA::FunctionTree::ParameterList &DataSample,
-                   unsigned int pos);
+std::shared_ptr<ComPWA::FunctionTree::TreeNode> createFunctionTree(
+    InputInfo Params,
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>>
+        InvMassSquared);
 
 } // namespace Voigtian
 

--- a/Physics/EvtGen/CMakeLists.txt
+++ b/Physics/EvtGen/CMakeLists.txt
@@ -1,7 +1,13 @@
 # Create EvtGen library.
 
-file(GLOB lib_srcs "*.cpp")
-file(GLOB lib_headers "*.hpp")
+file(GLOB lib_srcs 
+  DalitzKinematics.cpp
+  EvtGenIF.cpp 
+)
+file(GLOB lib_headers
+  DalitzKinematics.hpp
+  EvtGenIF.hpp
+)
 
 set(lib_srcs ${lib_srcs} ../SubSystem.cpp ../ParticleStateTransitionKinematicsInfo.cpp)
 set(lib_headers ${lib_headers} ../SubSystem.hpp)

--- a/Physics/EvtGen/DalitzKinematics.cpp
+++ b/Physics/EvtGen/DalitzKinematics.cpp
@@ -7,6 +7,7 @@
 #include "Core/Event.hpp"
 #include "Core/Logging.hpp"
 #include "Core/Particle.hpp"
+#include "Data/DataSet.hpp"
 
 #include "ThirdParty/qft++/include/qft++/Vector4.h"
 
@@ -50,200 +51,75 @@ DalitzKinematics::DalitzKinematics(
 
 double DalitzKinematics::phspVolume() const { return PhspVolume; }
 
-bool DalitzKinematics::isWithinPhsp(const DataPoint &point) const {
-  double mA = point.KinematicVariableList[0];
-  double mB = point.KinematicVariableList[1];
-  double mC = point.KinematicVariableList[2];
-  double qAB = point.KinematicVariableList[3];
-  double qBC = point.KinematicVariableList[4];
-  double qCA = point.KinematicVariableList[5];
+std::vector<ComPWA::Event> DalitzKinematics::reduceToPhaseSpace(
+    const std::vector<ComPWA::Event> &Events) const {
+  std::vector<Event> Evts;
 
-  double s2 = (qAB + qBC + qCA - mA * mA - mB * mB - mC * mC);
+  auto Dataset = convert(Events);
+  auto mA = Dataset.Data["mA"];
+  auto mB = Dataset.Data["mB"];
+  auto mC = Dataset.Data["mC"];
+  auto qAB = Dataset.Data["qAB"];
+  auto qBC = Dataset.Data["qBC"];
+  auto qCA = Dataset.Data["qCA"];
 
-  if (s2 < M2)
-    return true;
+  for (size_t i = 0; i < Events.size(); ++i) {
+    double s2 = (qAB[i] + qBC[i] + qCA[i] - mA[i] * mA[i] - mB[i] * mB[i] -
+                 mC[i] * mC[i]);
 
-  return false;
-}
-
-DataPoint DalitzKinematics::convert(const Event &event) const {
-
-  double mA, mB, mC, qAB, qBC, qCA;
-
-  mA = event.ParticleList[0].mass();
-  mB = event.ParticleList[1].mass();
-  mC = event.ParticleList[2].mass();
-  qAB = (event.ParticleList[0].fourMomentum() +
-         event.ParticleList[1].fourMomentum())
-            .invariantMass();
-  qBC = (event.ParticleList[1].fourMomentum() +
-         event.ParticleList[2].fourMomentum())
-            .invariantMass();
-  qCA = (event.ParticleList[2].fourMomentum() +
-         event.ParticleList[0].fourMomentum())
-            .invariantMass();
-
-  /*FourMomentum cms;
-  for (auto s : sys.GetRecoilState())
-    cms += event.particle(s).fourMomentum();
-
-  FourMomentum finalA, finalB;
-  for (auto s : sys.GetFinalStates().at(0))
-    finalA += event.particle(s).fourMomentum();
-
-assert(sys.GetFinalStates().size() == 2 &&
- "DalitzKinematics::convert() | More then two particles.");
-
-
-for (auto s : sys.GetFinalStates().at(1))
-finalB += event.particle(s).fourMomentum();
-
-// Four momentum of the decaying resonance
-FourMomentum resP4 = finalA + finalB;
-double mSq = resP4.invMassSq();
-
-// Calculate sum of final states four momenta
-cms += resP4;
-
-if (mSq <= limits.first) {
-// We allow for a deviation from the limits of 10 times the numerical
-// precision
-if (ComPWA::equal(mSq, limits.first, 10))
-mSq = limits.first;
-else
-throw BeyondPhsp("HelicityKinematics::convert() |"
-               " Point beypond phase space boundaries!");
-}
-if (mSq >= limits.second) {
-// We allow for a deviation from the limits of 10 times the numerical
-// precision
-if (ComPWA::equal(mSq, limits.second, 10))
-mSq = limits.second;
-else
-throw BeyondPhsp("HelicityKinematics::convert() |"
-               " Point beypond phase space boundaries!");
-}
-
-// When using finalB instead of finalA here, the WignerD changes sign. In
-// the end this does not matter
-QFT::Vector4<double> p4QftCms(cms);
-QFT::Vector4<double> p4QftResonance(resP4);
-QFT::Vector4<double> p4QftDaughter(finalB);
-
-// Boost the four momentum of the decaying resonance to total CMS
-p4QftResonance.Boost(p4QftCms);
-// Boost the four momentum of one daughter particle to CMS of the resonance
-p4QftDaughter.Boost(p4QftResonance);
-
-// Calculate the angles between recoil system and final state.
-// Use an Euler rotation of the coordinate system (wrong?)
-//   p4QftDaughter.Rotate(p4QftResonance.Phi(), p4QftResonance.Theta(),
-//                       (-1) * p4QftResonance.Phi());
-p4QftDaughter.RotateZ((-1) * p4QftResonance.Phi());
-p4QftDaughter.RotateY((-1) * p4QftResonance.Theta());
-
-double cosTheta = p4QftDaughter.CosTheta();
-double phi = p4QftDaughter.Phi();
-
-//  double cc;
-//  if (sys.GetRecoilState().size() == 1 &&
-//      sys.GetFinalStates().at(0).size() == 1 &&
-//      sys.GetFinalStates().at(1).size() == 1) {
-//    double invMassSqA = mSq;
-//    double invMassSqB = (recoilP4 + finalA).GetInvMassSq();
-//    auto mspec = PhysConst::Instance()
-// ->FindParticle(_finalState.at(sys.GetRecoilState().at(0)))
-//                     .GetMass();
-//    auto ma =
-//        PhysConst::Instance()
-//            ->FindParticle(_finalState.at(sys.GetFinalStates().at(0).at(0)))
-//            .GetMass();
-//    auto mb =
-//        PhysConst::Instance()
-//            ->FindParticle(_finalState.at(sys.GetFinalStates().at(1).at(0)))
-//            .GetMass();
-//    auto M =
-//    PhysConst::Instance()->FindParticle(_initialState.at(0)).GetMass();
-//
-//    cc = HelicityAngle(M, ma, mb, mspec, invMassSqA, invMassSqB);
-//    std::cout << sys << std::endl;
-//    std::cout << _initialState.at(0) << "/ (" <<
-// sys.GetFinalStates().at(0).at(0)
-//              << sys.GetFinalStates().at(1).at(0) << ") angle ("<<
-// sys.GetFinalStates().at(0).at(0)
-//              << sys.GetRecoilState().at(0) << ") - "
-//              << " (ma=" << ma<<" mb="<<mb<<" mSpec="<<mspec<<"
-// mABSq="<<invMassSqA << " mASpecSq=" << invMassSqB << ") = " << cc
-//              << " " << cosTheta << std::endl;
-//
-//  } else {
-//    cc = 1.0;
-//    phi = 0.0;
-//  }
-//  cosTheta = cc;
-
-//   Check if values are within allowed range.
-if (cosTheta > 1 || cosTheta < -1 || phi > M_PI || phi < (-1) * M_PI ||
-std::isnan(cosTheta) || std::isnan(phi)) {
-throw BeyondPhsp("HelicityKinematics::convert() |"
-             " Point beypond phase space boundaries!");
-}*/
-
-  // point.values().push_back(mSq);
-  // point.values().push_back(cosTheta);
-  // point.values().push_back(phi);
-
-  return DataPoint{.KinematicVariableList =
-                       std::vector<double>{mB, mC, qAB, qBC, qCA}};
-}
-
-double DalitzKinematics::helicityAngle(double M, double m, double m2,
-                                       double mSpec, double invMassSqA,
-                                       double invMassSqB) const {
-  // Calculate energy and momentum of m1/m2 in the invMassSqA rest frame
-  double eCms = (invMassSqA + m * m - m2 * m2) / (2 * sqrt(invMassSqA));
-  double pCms = eCms * eCms - m * m;
-  // Calculate energy and momentum of mSpec in the invMassSqA rest frame
-  double eSpecCms =
-      (M * M - mSpec * mSpec - invMassSqA) / (2 * sqrt(invMassSqA));
-  double pSpecCms = eSpecCms * eSpecCms - mSpec * mSpec;
-  double cosAngle =
-      -(invMassSqB - m * m - mSpec * mSpec - 2 * eCms * eSpecCms) /
-      (2 * sqrt(pCms * pSpecCms));
-
-  //  if( cosAngle>1 || cosAngle<-1 ){
-  //      throw BeyondPhsp("DalitzKinematics::helicityAngle() | "
-  //              "scattering angle out of range! Datapoint beyond phsp? angle="
-  //              +std::to_string((long double) cosAngle)
-  //      +" M="+std::to_string((long double) M)
-  //      +" m="+std::to_string((long double) m)
-  //      +" m2="+std::to_string((long double) m2)
-  //      +" mSpec="+std::to_string((long double) mSpec)
-  //      +" mSqA="+std::to_string((long double) invMassSqA)
-  //      +" mSqB="+std::to_string((long double) invMassSqB) );
-  //  }
-  if (cosAngle > 1 || cosAngle < -1) { // faster
-    throw BeyondPhsp("DalitzKinematics::helicityAngle() | "
-                     "scattering angle out of range! Datapoint beyond"
-                     "phsp?");
+    if (s2 < M2)
+      Evts.push_back(Events[i]);
   }
-  return cosAngle;
+  return Evts;
 }
 
-int DalitzKinematics::createIndex() {
+ComPWA::Data::DataSet
+DalitzKinematics::convert(const std::vector<Event> &Events) const {
 
-  if (VariableNames.size())
-    return 1;
+  ComPWA::Data::DataSet Dataset;
 
-  VariableNames.push_back("mA");
-  VariableNames.push_back("mB");
-  VariableNames.push_back("mC");
-  VariableNames.push_back("qAB");
-  VariableNames.push_back("qBC");
-  VariableNames.push_back("qCA");
-  //}
-  return 0;
+  std::vector<double> mA, mB, mC, qAB, qBC, qCA, weights;
+  for (auto const &event : Events) {
+    mA.push_back(event.ParticleList[0].mass());
+    mB.push_back(event.ParticleList[1].mass());
+    mC.push_back(event.ParticleList[2].mass());
+    qAB.push_back((event.ParticleList[0].fourMomentum() +
+                   event.ParticleList[1].fourMomentum())
+                      .invariantMass());
+    qBC.push_back((event.ParticleList[1].fourMomentum() +
+                   event.ParticleList[2].fourMomentum())
+                      .invariantMass());
+    qCA.push_back((event.ParticleList[2].fourMomentum() +
+                   event.ParticleList[0].fourMomentum())
+                      .invariantMass());
+    weights.push_back(event.Weight);
+  }
+
+  Dataset.Data.insert(std::make_pair("mA", mA));
+  Dataset.Data.insert(std::make_pair("mB", mB));
+  Dataset.Data.insert(std::make_pair("mC", mC));
+  Dataset.Data.insert(std::make_pair("qAB", qAB));
+  Dataset.Data.insert(std::make_pair("qBC", qBC));
+  Dataset.Data.insert(std::make_pair("qCA", qCA));
+  Dataset.Data.insert(std::make_pair("weights", weights));
+
+  return Dataset;
 }
+
+// int DalitzKinematics::createIndex() {
+
+//   if (VariableNames.size())
+//     return 1;
+
+//   VariableNames.push_back("mA");
+//   VariableNames.push_back("mB");
+//   VariableNames.push_back("mC");
+//   VariableNames.push_back("qAB");
+//   VariableNames.push_back("qBC");
+//   VariableNames.push_back("qCA");
+//   //}
+//   return 0;
+// }
 
 } // namespace EvtGen
 } // namespace Physics

--- a/Physics/EvtGen/DalitzKinematics.hpp
+++ b/Physics/EvtGen/DalitzKinematics.hpp
@@ -50,34 +50,11 @@ public:
   DalitzKinematics(const DalitzKinematics &that) = delete;
   DalitzKinematics(DalitzKinematics &&that) = default;
 
-  /// Fill \p point from \p event.
-  /// For each SubSystem stored via dataID(const SubSystem subSys) function
-  /// #convert(const Event&, dataPoint&, SubSystem,
-  /// const std::pair<double, double>) is called. In this way only
-  /// the variables are calculated that are used by the model.
-  DataPoint convert(const Event &event) const;
+  ComPWA::Data::DataSet convert(const std::vector<Event> &Events) const final;
 
-  /// Check if \p point is within phase space boundaries.
-  bool isWithinPhsp(const DataPoint &point) const;
-
-  /// Get number of variables that are added to dataPoint
-  virtual size_t numVariables() const { return 6; }
-
-  /// Calculation of helicity angle.
-  /// See (Martin and Spearman, Elementary Particle Theory. 1970)
-  /// \deprecated Only used as cross-check.
-  double helicityAngle(double M, double m, double m2, double mSpec,
-                       double invMassSqA, double invMassSqB) const;
-
-  int dataID(const ComPWA::Physics::SubSystem &) { return 0; }
-
-  virtual unsigned int getDataID(const ComPWA::Physics::SubSystem &) const {
-    return 0;
-  }
-
-  std::vector<std::string> getKinematicVariableNames() const {
-    return VariableNames;
-  }
+  /// Returns a subset of \p Events that are within phase space boundaries.
+  std::vector<ComPWA::Event>
+  reduceToPhaseSpace(const std::vector<ComPWA::Event> &Events) const final;
 
   double phspVolume() const;
 
@@ -87,13 +64,6 @@ private:
   double PhspVolume;
 
   double M2;
-
-  std::vector<std::string> VariableNames;
-
-  /// Add \p newSys to list of SubSystems and return its ID.
-  /// In case that this SubSystem is already in the list only the ID is
-  /// returned.
-  int createIndex();
 };
 
 } // namespace EvtGen

--- a/Physics/EvtGen/EvtGenIF.cpp
+++ b/Physics/EvtGen/EvtGenIF.cpp
@@ -192,13 +192,12 @@ void EvtGenIF::addResonances(const boost::property_tree::ptree &pt,
   LOG(DEBUG) << "EvtGenIF::addResoances finished";
 }
 
-std::vector<double>
-EvtGenIF::evaluate(const std::vector<std::vector<double>> &data) noexcept {
+std::vector<double> EvtGenIF::evaluate(const ComPWA::DataMap &data) noexcept {
   std::vector<double> Results;
-  for (size_t EventIndex = 0; EventIndex < data[0].size(); ++EventIndex) {
-    EvtDalitzPoint pnt(data[0][EventIndex], data[1][EventIndex],
-                       data[2][EventIndex], data[3][EventIndex],
-                       data[4][EventIndex], data[5][EventIndex]);
+  for (size_t EventIndex = 0; EventIndex < data.at("mA").size(); ++EventIndex) {
+    EvtDalitzPoint pnt(data.at("mA")[EventIndex], data.at("mB")[EventIndex],
+                       data.at("mC")[EventIndex], data.at("qAB")[EventIndex],
+                       data.at("qBC")[EventIndex], data.at("qCA")[EventIndex]);
     double result = 0;
 
     for (unsigned int i = 0; i < Resos.size(); ++i) {

--- a/Physics/EvtGen/EvtGenIF.hpp
+++ b/Physics/EvtGen/EvtGenIF.hpp
@@ -2,17 +2,18 @@
 // This file is part of the ComPWA framework, check
 // https://github.com/ComPWA/ComPWA/license.txt for details.
 
+#ifndef COMPWA_PHYSICS_EVTGEN_EVTGENIF_HPP
+#define COMPWA_PHYSICS_EVTGEN_EVTGENIF_HPP
+
 #include "Core/Event.hpp"
 #include "Core/FunctionTree/FitParameter.hpp"
 #include "Core/Logging.hpp"
+#include "Data/DataSet.hpp"
 #include "Physics/EvtGen/DalitzKinematics.hpp"
 #include "Physics/SubSystem.hpp"
 #include "ThirdParty/EvtGen/EvtDalitzPlot.hh"
 #include "ThirdParty/EvtGen/EvtDalitzReso.hh"
 #include "Tools/Integration.hpp"
-
-#ifndef COMPWA_PHYSICS_EVTGEN_EVTGENIF_HPP
-#define COMPWA_PHYSICS_EVTGEN_EVTGENIF_HPP
 
 namespace ComPWA {
 namespace Physics {
@@ -41,8 +42,7 @@ public:
                      std::shared_ptr<DalitzKinematics> kin,
                      const ComPWA::ParticleList &partL);
 
-  std::vector<double>
-  evaluate(const std::vector<std::vector<double>> &data) noexcept;
+  std::vector<double> evaluate(const ComPWA::DataMap &data) noexcept;
 
   /// It is important to input the vector in the same length and order as
   /// defined in the getParameters() method. So in other words, call
@@ -55,9 +55,8 @@ public:
   /// We use a phase space sample to calculate the normalization and determine
   /// the maximum of the amplitude. In case that the efficiency is already
   /// applied to the sample set fEff to false.
-  virtual void
-  setPhspSample(std::shared_ptr<std::vector<ComPWA::DataPoint>> phspSample,
-                std::shared_ptr<std::vector<ComPWA::DataPoint>> toySample) {
+  virtual void setPhspSample(std::shared_ptr<ComPWA::Data::DataSet> phspSample,
+                             std::shared_ptr<ComPWA::Data::DataSet> toySample) {
     PhspSample = phspSample;
   };
 
@@ -65,7 +64,7 @@ public:
 
 private:
   /// Phase space sample to calculate the normalization and maximum value.
-  std::shared_ptr<std::vector<ComPWA::DataPoint>> PhspSample;
+  std::shared_ptr<ComPWA::Data::DataSet> PhspSample;
 
   double PhspVolume;
 
@@ -79,13 +78,6 @@ private:
 
   EvtDalitzPlot DalitzPlot;
   std::vector<EvtDalitzReso> Resos;
-
-  EvtDalitzPoint transformToEvt(const ComPWA::DataPoint &point) const {
-    return EvtDalitzPoint(
-        point.KinematicVariableList[0], point.KinematicVariableList[1],
-        point.KinematicVariableList[2], point.KinematicVariableList[3],
-        point.KinematicVariableList[4], point.KinematicVariableList[5]);
-  }
 };
 
 } // namespace EvtGen

--- a/Physics/HelicityFormalism/HelicityKinematics.cpp
+++ b/Physics/HelicityFormalism/HelicityKinematics.cpp
@@ -12,6 +12,7 @@
 #include "Core/Logging.hpp"
 #include "Core/Particle.hpp"
 #include "Core/Properties.hpp"
+#include "Data/DataSet.hpp"
 #include "Physics/HelicityFormalism/HelicityKinematics.hpp"
 
 #include "qft++/Vector4.h"
@@ -50,48 +51,221 @@ HelicityKinematics::HelicityKinematics(ParticleStateTransitionKinematicsInfo ki,
 
 double HelicityKinematics::phspVolume() const { return PhspVolume; }
 
-bool HelicityKinematics::isWithinPhaseSpace(const DataPoint &point) const {
-  unsigned int pos = 0;
-  for (auto bounds : InvMassBounds) {
-    if (point.KinematicVariableList[pos] < bounds.first ||
-        point.KinematicVariableList[pos] > bounds.second) {
-      return false;
-    }
-    if (point.KinematicVariableList[pos + 1] < 0 ||
-        point.KinematicVariableList[pos + 1] > M_PI)
-      return false;
-    if (point.KinematicVariableList[pos + 2] < -M_PI ||
-        point.KinematicVariableList[pos + 2] > M_PI)
-      return false;
+std::vector<Event>
+HelicityKinematics::reduceToPhaseSpace(const std::vector<Event> &Events) const {
+  std::vector<Event> tmp;
+  LOG(INFO) << "HelicityKinematics::reduceToPhaseSpace(): "
+               "Remove all events outside PHSP boundary from data sample.";
 
-    pos += 3;
-  }
+  std::copy_if(
+      Events.begin(), Events.end(), std::back_inserter(tmp), [this](auto evt) {
+        for (auto const &x : InvariantMassesSquared) {
+          auto bounds = InvMassBounds.at(x.second);
+          double mass = this->calculateInvariantMassSquared(evt, x.first);
+          if (mass < bounds.first || mass > bounds.second)
+            return false;
+        }
+        for (auto const &x : Subsystems) {
+          auto angles = this->calculateHelicityAngles(evt, x.first);
+          if (angles.first < 0 || angles.first > M_PI)
+            return false;
+          if (angles.second < -M_PI || angles.second > M_PI)
+            return false;
+        }
+        return true;
+      });
 
-  return true;
+  LOG(INFO) << "reduceToPhaseSpace(): Removed " << Events.size() - tmp.size()
+            << " from " << Events.size() << " Events ("
+            << (1.0 - tmp.size() / Events.size()) * 100 << "%).";
+
+  return tmp;
 }
 
-DataPoint HelicityKinematics::convert(const Event &event) const {
-  assert(Subsystems.size() == InvMassBounds.size());
+std::pair<double, double>
+HelicityKinematics::calculateHelicityAngles(const Event &Event,
+                                            const SubSystem &SubSys) const {
+  FourMomentum FinalA, FinalB;
+  for (auto s : SubSys.getFinalStates().at(0)) {
+    unsigned int index = KinematicsInfo.convertFinalStateIDToPositionIndex(s);
+    FinalA += Event.ParticleList[index].fourMomentum();
+  }
 
+  for (auto s : SubSys.getFinalStates().at(1)) {
+    unsigned int index = KinematicsInfo.convertFinalStateIDToPositionIndex(s);
+    FinalB += Event.ParticleList[index].fourMomentum();
+  }
+
+  // Four momentum of the decaying resonance
+  FourMomentum State = FinalA + FinalB;
+
+  QFT::Vector4<double> DecayingState(State);
+  QFT::Vector4<double> Daughter(FinalA);
+
+  // calculate the recoil and parent recoil
+  auto const &RecoilState = SubSys.getRecoilState();
+
+  // the first step is boosting everything into the rest system of the
+  // decaying state
+  Daughter.Boost(DecayingState);
+
+  if (RecoilState.size() > 0) {
+    FourMomentum TempRecoil;
+    for (auto s : RecoilState) {
+      unsigned int index = KinematicsInfo.convertFinalStateIDToPositionIndex(s);
+      TempRecoil += Event.ParticleList[index].fourMomentum();
+    }
+    QFT::Vector4<double> Recoil(TempRecoil);
+
+    Recoil.Boost(DecayingState);
+
+    // rotate recoil so that recoil points in the z direction
+    Daughter.RotateZ(-Recoil.Phi());
+    Daughter.RotateY(M_PI - Recoil.Theta());
+
+    auto const &ParentRecoilState = SubSys.getParentRecoilState();
+    // in case there is no parent recoil, it is artificially along z
+    QFT::Vector4<double> ParentRecoil(0.0, 0.0, 0.0, 1.0);
+    if (ParentRecoilState.size() > 0) {
+      FourMomentum TempParentRecoil;
+      for (auto s : ParentRecoilState) {
+        unsigned int index =
+            KinematicsInfo.convertFinalStateIDToPositionIndex(s);
+        TempParentRecoil += Event.ParticleList[index].fourMomentum();
+      }
+      ParentRecoil = TempParentRecoil;
+    }
+
+    ParentRecoil.Boost(DecayingState);
+    ParentRecoil.RotateZ(-Recoil.Phi());
+    ParentRecoil.RotateY(M_PI - Recoil.Theta());
+
+    // rotate around the z-axis so that the parent recoil lies in the x-z
+    // plane
+    Daughter.RotateZ(M_PI - ParentRecoil.Phi());
+  }
+
+  double cosTheta = Daughter.CosTheta();
+  double phi = Daughter.Phi();
+
+  return std::make_pair(std::acos(cosTheta), phi);
+}
+
+double HelicityKinematics::calculateInvariantMassSquared(
+    const Event &Event, const IndexList &FinalStateIDs) const {
+  FourMomentum State;
+  for (auto s : FinalStateIDs) {
+    unsigned int index = KinematicsInfo.convertFinalStateIDToPositionIndex(s);
+    State += Event.ParticleList[index].fourMomentum();
+  }
+
+  return State.invariantMassSquared();
+}
+
+ComPWA::Data::DataSet
+HelicityKinematics::convert(const std::vector<ComPWA::Event> &Events) const {
+  ComPWA::Data::DataSet Dataset;
   if (!Subsystems.size()) {
     LOG(ERROR) << "HelicityKinematics::convert() | No variables were "
                   "requested before. Therefore this function is doing nothing!";
+    return Dataset;
   }
-  DataPoint point;
-  for (unsigned int i = 0; i < Subsystems.size(); i++)
-    convert(event, point, Subsystems.at(i), InvMassBounds.at(i));
-  return point;
+
+  for (auto const &x : InvariantMassesSquared) {
+    Dataset.Data.insert(std::make_pair(x.second, std::vector<double>()));
+    for (auto const &event : Events) {
+      auto Mass = calculateInvariantMassSquared(event, x.first);
+      Dataset.Data.at(x.second).push_back(Mass);
+    }
+  }
+  for (auto const &x : Subsystems) {
+    Dataset.Data.insert(std::make_pair(x.second.first, std::vector<double>()));
+    Dataset.Data.insert(std::make_pair(x.second.second, std::vector<double>()));
+    for (auto const &event : Events) {
+      auto Angles = calculateHelicityAngles(event, x.first);
+      Dataset.Data.at(x.second.first).push_back(Angles.first);
+      Dataset.Data.at(x.second.second).push_back(Angles.second);
+    }
+  }
+  for (auto const &event : Events) {
+    Dataset.Weights.push_back(event.Weight);
+  }
+  return Dataset;
 }
 
-void HelicityKinematics::convert(const Event &event, DataPoint &point,
-                                 const SubSystem &sys) const {
-  auto massLimits = invMassBounds(sys);
-  convert(event, point, sys, massLimits);
+std::string
+HelicityKinematics::registerInvariantMassSquared(IndexList MomentaIDs) {
+  std::sort(MomentaIDs.begin(), MomentaIDs.end());
+  std::stringstream Name;
+  Name << "mSq_(";
+  std::string comma("");
+  for (auto x : MomentaIDs) {
+    Name << comma << x;
+    comma = ",";
+  }
+  Name << ")";
+
+  InvMassBounds.insert(
+      std::make_pair(Name.str(), calculateInvMassBounds(MomentaIDs)));
+  InvariantMassesSquared.insert(std::make_pair(MomentaIDs, Name.str()));
+  return Name.str();
 }
 
-unsigned int HelicityKinematics::getDataID(const SubSystem &subSys) const {
-  auto const result = std::find(Subsystems.begin(), Subsystems.end(), subSys);
-  return result - Subsystems.begin();
+std::pair<std::string, std::string>
+HelicityKinematics::registerHelicityAngles(SubSystem SubSys) {
+  std::stringstream ss;
+  ss << SubSys;
+
+  std::string ThetaName("theta" + ss.str());
+  std::string PhiName("phi" + ss.str());
+
+  Subsystems.insert(std::make_pair(SubSys, std::make_pair(ThetaName, PhiName)));
+  return std::make_pair(ThetaName, PhiName);
+}
+
+std::vector<std::pair<ComPWA::IndexList, ComPWA::IndexList>>
+redistributeIndexLists(const ComPWA::IndexList &A, const ComPWA::IndexList &B) {
+  using ComPWA::IndexList;
+  std::vector<std::pair<IndexList, IndexList>> NewIndexLists;
+  if (A.size() < B.size())
+    throw std::runtime_error("HelicityKinematics::redistributeIndexLists(): A "
+                             "cannot have less content than B!");
+  if (A.size() == 2 && B.size() == 0) {
+    NewIndexLists.push_back(std::make_pair(IndexList{A[0]}, IndexList{A[1]}));
+  } else if (A.size() - B.size() > 1) {
+    for (unsigned int i = 0; i < A.size(); ++i) {
+      IndexList TempB(B);
+      TempB.push_back(A[i]);
+      IndexList TempA(A);
+      TempA.erase(TempA.begin() + i);
+      NewIndexLists.push_back(std::make_pair(TempA, TempB));
+    }
+  }
+  return NewIndexLists;
+}
+
+using IndexListTuple = std::tuple<IndexList, IndexList, IndexList, IndexList>;
+
+IndexListTuple sortSubsystem(const IndexListTuple &SubSys) {
+  IndexList FinalStateA(std::get<0>(SubSys));
+  IndexList FinalStateB(std::get<1>(SubSys));
+  IndexList RecoilState(std::get<2>(SubSys));
+  IndexList ParentRecoilState(std::get<3>(SubSys));
+
+  // create sorted entry
+  std::sort(FinalStateA.begin(), FinalStateA.end());
+  std::sort(FinalStateB.begin(), FinalStateB.end());
+  std::sort(RecoilState.begin(), RecoilState.end());
+  std::sort(ParentRecoilState.begin(), ParentRecoilState.end());
+
+  IndexListTuple SortedTuple;
+  if (FinalStateA > FinalStateB)
+    SortedTuple = std::make_tuple(FinalStateB, FinalStateA, RecoilState,
+                                  ParentRecoilState);
+  else
+    SortedTuple = std::make_tuple(FinalStateA, FinalStateB, RecoilState,
+                                  ParentRecoilState);
+  return SortedTuple;
 }
 
 void HelicityKinematics::createAllSubsystems() {
@@ -100,16 +274,16 @@ void HelicityKinematics::createAllSubsystems() {
 
   std::vector<IndexListTuple> AllSubsystems;
   // add current subsystems
-  for (auto const &SubSys : subSystems()) {
+  for (auto const &SubSys : Subsystems) {
     AllSubsystems.push_back(
         std::make_tuple(KinematicsInfo.convertFinalStateIDToPositionIndex(
-                            SubSys.getFinalStates()[0]),
+                            SubSys.first.getFinalStates()[0]),
                         KinematicsInfo.convertFinalStateIDToPositionIndex(
-                            SubSys.getFinalStates()[1]),
+                            SubSys.first.getFinalStates()[1]),
                         KinematicsInfo.convertFinalStateIDToPositionIndex(
-                            SubSys.getRecoilState()),
+                            SubSys.first.getRecoilState()),
                         KinematicsInfo.convertFinalStateIDToPositionIndex(
-                            SubSys.getParentRecoilState())));
+                            SubSys.first.getParentRecoilState())));
   }
 
   IndexList FinalStateIDs(KinematicsInfo.getFinalStateParticleCount());
@@ -165,81 +339,34 @@ void HelicityKinematics::createAllSubsystems() {
     }
   }
   for (auto const &x : AllSubsystems) {
-    addSubSystem(std::get<0>(x), std::get<1>(x), std::get<2>(x),
-                 std::get<3>(x));
+    registerSubSystem(std::get<0>(x), std::get<1>(x), std::get<2>(x),
+                      std::get<3>(x));
   }
 }
 
-HelicityKinematics::IndexListTuple
-HelicityKinematics::sortSubsystem(const IndexListTuple &SubSys) const {
-  IndexList FinalStateA(std::get<0>(SubSys));
-  IndexList FinalStateB(std::get<1>(SubSys));
-  IndexList RecoilState(std::get<2>(SubSys));
-  IndexList ParentRecoilState(std::get<3>(SubSys));
-
-  // create sorted entry
-  std::sort(FinalStateA.begin(), FinalStateA.end());
-  std::sort(FinalStateB.begin(), FinalStateB.end());
-  std::sort(RecoilState.begin(), RecoilState.end());
-  std::sort(ParentRecoilState.begin(), ParentRecoilState.end());
-
-  IndexListTuple SortedTuple;
-  if (FinalStateA > FinalStateB)
-    SortedTuple = std::make_tuple(FinalStateB, FinalStateA, RecoilState,
-                                  ParentRecoilState);
-  else
-    SortedTuple = std::make_tuple(FinalStateA, FinalStateB, RecoilState,
-                                  ParentRecoilState);
-  return SortedTuple;
-}
-
-std::vector<std::pair<IndexList, IndexList>>
-HelicityKinematics::redistributeIndexLists(const IndexList &A,
-                                           const IndexList &B) const {
-  std::vector<std::pair<IndexList, IndexList>> NewIndexLists;
-  if (A.size() < B.size())
-    throw std::runtime_error("HelicityKinematics::redistributeIndexLists(): A "
-                             "cannot have less content than B!");
-  if (A.size() == 2 && B.size() == 0) {
-    NewIndexLists.push_back(std::make_pair(IndexList{A[0]}, IndexList{A[1]}));
-  } else if (A.size() - B.size() > 1) {
-    for (unsigned int i = 0; i < A.size(); ++i) {
-      IndexList TempB(B);
-      TempB.push_back(A[i]);
-      IndexList TempA(A);
-      TempA.erase(TempA.begin() + i);
-      NewIndexLists.push_back(std::make_pair(TempA, TempB));
-    }
-  }
-  return NewIndexLists;
-}
-
-unsigned int HelicityKinematics::addSubSystem(const SubSystem &subSys) {
+std::tuple<std::string, std::string, std::string>
+HelicityKinematics::registerSubSystem(const SubSystem &NewSys) {
   // We calculate the variables currently for two-body decays
-  if (subSys.getFinalStates().size() != 2) {
+  if (NewSys.getFinalStates().size() != 2) {
     std::stringstream ss;
-    ss << "HelicityKinematics::addSubSystem(const SubSystem "
+    ss << "HelicityKinematics::registerSubSystem(const SubSystem "
           "&subSys): Number of final state particles = "
-       << subSys.getFinalStates().size() << ", which is != 2";
+       << NewSys.getFinalStates().size() << ", which is != 2";
     throw std::runtime_error(ss.str());
   }
-  unsigned int pos(Subsystems.size());
-  auto const result = std::find(Subsystems.begin(), Subsystems.end(), subSys);
-  if (result == Subsystems.end()) {
-    Subsystems.push_back(subSys);
-    InvMassBounds.push_back(calculateInvMassBounds(subSys));
-    std::stringstream ss;
-    ss << subSys;
-    VariableNames.push_back("mSq" + ss.str());
-    VariableNames.push_back("theta" + ss.str());
-    VariableNames.push_back("phi" + ss.str());
-  } else {
-    pos = result - Subsystems.begin();
-  }
-  return pos;
+
+  IndexList FS1 = NewSys.getFinalStates().at(0);
+  IndexList FS2 = NewSys.getFinalStates().at(1);
+  FS1.insert(FS1.end(), FS2.begin(), FS2.end());
+
+  auto MassName = registerInvariantMassSquared(FS1);
+  auto AngleNames = registerHelicityAngles(NewSys);
+
+  return std::make_tuple(MassName, AngleNames.first, AngleNames.second);
 }
 
-unsigned int HelicityKinematics::addSubSystem(
+std::tuple<std::string, std::string, std::string>
+HelicityKinematics::registerSubSystem(
     const std::vector<unsigned int> &FinalA,
     const std::vector<unsigned int> &FinalB,
     const std::vector<unsigned int> &Recoil,
@@ -256,118 +383,22 @@ unsigned int HelicityKinematics::addSubSystem(
   std::vector<unsigned int> ConvertedParentRecoil =
       KinematicsInfo.convertPositionIndexToFinalStateID(ParentRecoil);
 
-  return addSubSystem(
+  return registerSubSystem(
       SubSystem(ConvertedFinalStates, ConvertedRecoil, ConvertedParentRecoil));
 }
 
-double HelicityKinematics::helicityAngle(double M, double m, double m2,
-                                         double mSpec, double invMassSqA,
-                                         double invMassSqB) const {
-  // Calculate energy and momentum of m1/m2 in the invMassSqA rest frame
-  double eCms = (invMassSqA + m * m - m2 * m2) / (2.0 * std::sqrt(invMassSqA));
-  double pCms = eCms * eCms - m * m;
-  // Calculate energy and momentum of mSpec in the invMassSqA rest frame
-  double eSpecCms =
-      (M * M - mSpec * mSpec - invMassSqA) / (2.0 * std::sqrt(invMassSqA));
-  double pSpecCms = eSpecCms * eSpecCms - mSpec * mSpec;
-  double cosAngle =
-      -(invMassSqB - m * m - mSpec * mSpec - 2.0 * eCms * eSpecCms) /
-      (2.0 * std::sqrt(pCms * pSpecCms));
-
-  return cosAngle;
+const std::pair<double, double> &HelicityKinematics::getInvariantMassBounds(
+    const std::string &InvariantMassName) const {
+  return InvMassBounds.at(InvariantMassName);
 }
 
-void HelicityKinematics::convert(
-    const Event &event, DataPoint &point, const SubSystem &sys,
-    const std::pair<double, double> &limits) const {
-  FourMomentum FinalA, FinalB;
-  for (auto s : sys.getFinalStates().at(0)) {
-    unsigned int index = KinematicsInfo.convertFinalStateIDToPositionIndex(s);
-    FinalA += event.ParticleList[index].fourMomentum();
-  }
-
-  for (auto s : sys.getFinalStates().at(1)) {
-    unsigned int index = KinematicsInfo.convertFinalStateIDToPositionIndex(s);
-    FinalB += event.ParticleList[index].fourMomentum();
-  }
-
-  // Four momentum of the decaying resonance
-  FourMomentum State = FinalA + FinalB;
-  double mSq = State.invariantMassSquared();
-
-  QFT::Vector4<double> DecayingState(State);
-  QFT::Vector4<double> Daughter(FinalA);
-
-  // calculate the recoil and parent recoil
-  auto const &RecoilState = sys.getRecoilState();
-
-  // the first step is boosting everything into the rest system of the
-  // decaying state
-  Daughter.Boost(DecayingState);
-
-  if (RecoilState.size() > 0) {
-    FourMomentum TempRecoil;
-    for (auto s : RecoilState) {
-      unsigned int index = KinematicsInfo.convertFinalStateIDToPositionIndex(s);
-      TempRecoil += event.ParticleList[index].fourMomentum();
-    }
-    QFT::Vector4<double> Recoil(TempRecoil);
-
-    Recoil.Boost(DecayingState);
-
-    // rotate recoil so that recoil points in the z direction
-    Daughter.RotateZ(-Recoil.Phi());
-    Daughter.RotateY(M_PI - Recoil.Theta());
-
-    auto const &ParentRecoilState = sys.getParentRecoilState();
-    // in case there is no parent recoil, it is artificially along z
-    QFT::Vector4<double> ParentRecoil(0.0, 0.0, 0.0, 1.0);
-    if (ParentRecoilState.size() > 0) {
-      FourMomentum TempParentRecoil;
-      for (auto s : ParentRecoilState) {
-        unsigned int index =
-            KinematicsInfo.convertFinalStateIDToPositionIndex(s);
-        TempParentRecoil += event.ParticleList[index].fourMomentum();
-      }
-      ParentRecoil = TempParentRecoil;
-    }
-
-    ParentRecoil.Boost(DecayingState);
-    ParentRecoil.RotateZ(-Recoil.Phi());
-    ParentRecoil.RotateY(M_PI - Recoil.Theta());
-
-    // rotate around the z-axis so that the parent recoil lies in the x-z
-    // plane
-    Daughter.RotateZ(M_PI - ParentRecoil.Phi());
-  }
-
-  double cosTheta = Daughter.CosTheta();
-  double phi = Daughter.Phi();
-
-  point.Weight = event.Weight;
-  point.KinematicVariableList.push_back(mSq);
-  point.KinematicVariableList.push_back(std::acos(cosTheta));
-  point.KinematicVariableList.push_back(phi);
-}
-
-const std::pair<double, double> &
-HelicityKinematics::invMassBounds(const SubSystem &sys) const {
-  return invMassBounds(getDataID(sys));
-}
-
-const std::pair<double, double> &
-HelicityKinematics::invMassBounds(unsigned int sysID) const {
-  return InvMassBounds.at(sysID);
-}
-
-std::pair<double, double>
-HelicityKinematics::calculateInvMassBounds(const SubSystem &sys) const {
+std::pair<double, double> HelicityKinematics::calculateInvMassBounds(
+    const IndexList &FinalStateIDs) const {
   /// We use the formulae from (PDG2016 Kinematics Fig.47.3). I hope the
   /// generalization to n-body decays is correct.
   std::pair<double, double> lim(0.0, 0.0);
   // Sum up masses of all final state particles
-  for (auto j : sys.getFinalStates())
-    lim.first += KinematicsInfo.calculateFinalStateIDMassSum(j);
+  lim.first = KinematicsInfo.calculateFinalStateIDMassSum(FinalStateIDs);
 
   double S = KinematicsInfo.getInitialStateInvariantMassSquared();
   double RemainderMass(0.0);

--- a/Physics/HelicityFormalism/HelicityKinematics.cpp
+++ b/Physics/HelicityFormalism/HelicityKinematics.cpp
@@ -119,7 +119,7 @@ HelicityKinematics::calculateHelicityAngles(const Event &Event,
 
     Recoil.Boost(DecayingState);
 
-    // rotate recoil so that recoil points in the z direction
+    // rotate recoil so that recoil points in the -z direction
     Daughter.RotateZ(-Recoil.Phi());
     Daughter.RotateY(M_PI - Recoil.Theta());
 

--- a/Physics/HelicityFormalism/HelicityKinematics.hpp
+++ b/Physics/HelicityFormalism/HelicityKinematics.hpp
@@ -21,43 +21,25 @@ namespace HelicityFormalism {
 /// using the helicity formalism.
 /// The basic functionality is the calculatation of the kinematics variables
 /// from four-momenta.
-/// The variables that are used by a Resonance within a
-/// AmpIntensity depend on the SubSystem in which the Resonance appears.
-/// For the helicity formalism for each SubSystem the invariant mass \f$m^2\f$,
-/// and the helicity angles \f$cos\Theta\f$ and \f$\phi\f$ are calculated
-/// (\ref helicityangles).
+/// \see ComPWA::Data::DataSet convert(const std::vector<ComPWA::Event> &Events)
+/// const;
 ///
-/// The SubSystem is basically defined by the four-momenta of the resonance
-/// decay
-/// products and the sum of four-momenta of all other final state particles in
-/// the decay. Since usually a large number of possible SubSystems can be
-/// defined
-/// in a particle decay but only few of them are used, we introuce a bookkeeping
-/// system (\ref dataID). This increases efficiency (cpu+memory) significantly.
+/// Each SubSystem defines three kinematic variables: the invariant mass
+/// \f$m^2\f$, and the helicity angles \f$\Theta\f$ and \f$\phi\f$ are
+/// calculated
 ///
-/// \section dataID DataID
-///
-/// lsdafds
-/// \see dataID(SubSystem s)
-///
-/// \section helicityangles Helicity Angles
-///
-/// The helicity angles \f$cos\Theta\f$ and \f$\phi\f$ are defined as follows:
-/// A resonance R originating from another particles decays to two final state
-/// particles \f$f_1,f_2\f$.
-/// The momentum of the resonance R is shown in the rest frame of the parent
-/// decay
-/// while the momenta of the final state particles are boosted to the rest frame
-/// of the resonance. The helicity angles \f$cos\Theta\f$ and \f$\phi\f$ are
-/// then
-/// calculated between the momentum direction of \f$f_1\f$ (or \f$f_2\f$) and
-/// the
-/// momentum direction of the resonance.
-/// A (two-dimensional) illustration is given below
-/// \image html HelicityAngle.png "Helicity angle"
-/// \see convert(const Event &event, dataPoint &point, SubSystem sys,
-///                     const std::pair<double, double> limits) const;
-///
+/// A SubSystem uniquely defines a two body decay based on the participating
+/// four-momenta: the two final states (which make up the decaying state), the
+/// decaying state recoil system, and the parents recoil).
+/// Since usually a large number of possible SubSystems can be defined in a
+/// particle decay but not all of them are used, bookkeeping system is
+/// introduced. This increases efficiency (cpu+memory) significantly.
+/// Kinematic variables can be registered for calculation via the register
+/// methods:
+/// -# \see registerSubSystem();
+/// -# \see std::string registerInvariantMassSquared(IndexList System);
+/// -# \see std::pair<std::string, std::string> registerHelicityAngles(SubSystem
+/// System);
 ///
 class HelicityKinematics : public ComPWA::Kinematics {
 public:
@@ -84,15 +66,22 @@ public:
   /// Calculates the pair of values \f$(\Theta, \phi)\f$ of the Event \p Event
   /// for SubSystem \p SubSys. The step-by-step procedure to calculate the
   /// helicity angles is:
-  ///     -# Calculate four-momenta of center-of-mass system, resonance and of
-  ///        one final state particle  by summing up the corresponding
-  ///        four-momenta given by \p Event.
-  ///     -# Boost the four-momentum of the resonance to the center-of-mass
-  ///        frame of the parent decay.
-  ///     -# Boost the four-momentum of the final state particle in the rest
-  ///        frame of the resonance.
-  ///     -# Calculate \f$\Theta\f$ and \f$\phi\f$ between those boosted
-  ///        momenta.
+  ///     -# Calculate the four-momentum of center-of-mass system of the decay,
+  ///     by summing up all final state particle four-momenta.
+  ///     -# Boost the the final state particles, the recoil and the parent
+  ///     recoil into the CMS of the decaying state.
+  ///     -# Rotate the whole CMS system so that the recoil of the decaying
+  ///     state points in the -z-axis direction. This makes the z-axis the path
+  ///     of flight of the decaying state.
+  ///     -# Then rotate the CMS system so that the parent recoil lies in the
+  ///     x-z plane. This defines the angle \f$\phi\f$ of the current
+  ///     transformed final state particles as the angle differnce with respect
+  ///     to the production plane.
+  ///     -# The helicity angles \f$\Theta\f$ and \f$\phi\f$ can now simply be
+  ///     read of the momenta of the final state particles.
+  ///
+  /// A (two-dimensional) illustration is given below \image html
+  /// HelicityAngle.png "Helicity angle"
   std::pair<double, double>
   calculateHelicityAngles(const Event &Event, const SubSystem &SubSys) const;
 
@@ -102,7 +91,7 @@ public:
   double calculateInvariantMassSquared(const Event &Event,
                                        const IndexList &FinalStateIDs) const;
 
-  /// Creates a #DataSet from \p Events.
+  /// Creates a DataSet from \p Events.
   /// Calulates all registered kinematic variables for all Events. Kinematic
   /// variables can be registered for example via the #registerSubSystem(const
   /// SubSystem &newSys) method (see also other register methods). In this way
@@ -149,9 +138,12 @@ private:
 
   double PhspVolume;
 
-  /// List of subsystems for which invariant mass and angles are calculated
+  /// Mapping of subsystems to the corresponding helicity angle variable names
+  /// (theta, phi)
   std::unordered_map<SubSystem, std::pair<std::string, std::string>> Subsystems;
 
+  /// Mapinng of final state particle index lists to invariant mass variable
+  /// name
   std::unordered_map<IndexList, std::string> InvariantMassesSquared;
 
   /// Invariant mass bounds for each SubSystem

--- a/Physics/HelicityFormalism/WignerD.cpp
+++ b/Physics/HelicityFormalism/WignerD.cpp
@@ -10,10 +10,10 @@ namespace HelicityFormalism {
 
 using namespace ComPWA::FunctionTree;
 
-std::shared_ptr<ComPWA::FunctionTree::TreeNode>
-WignerD::createFunctionTree(double J, double MuPrime, double Mu,
-                            const ComPWA::FunctionTree::ParameterList &sample,
-                            int posTheta, int posPhi) {
+std::shared_ptr<ComPWA::FunctionTree::TreeNode> WignerD::createFunctionTree(
+    double J, double MuPrime, double Mu,
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>> Theta,
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>> Phi) {
 
   // in case of spin zero do not explicitly include the WignerD
   if ((double)J == 0)
@@ -25,8 +25,8 @@ WignerD::createFunctionTree(double J, double MuPrime, double Mu,
   tr->addNodes({FunctionTree::createLeaf(J, "J"),
                 FunctionTree::createLeaf(MuPrime, "mu'"),
                 FunctionTree::createLeaf(Mu, "mu"),
-                FunctionTree::createLeaf(sample.mDoubleValue(posTheta)),
-                FunctionTree::createLeaf(sample.mDoubleValue(posPhi))});
+                FunctionTree::createLeaf(Theta),
+                FunctionTree::createLeaf(Phi)});
 
   return tr;
 }

--- a/Physics/HelicityFormalism/WignerD.hpp
+++ b/Physics/HelicityFormalism/WignerD.hpp
@@ -62,10 +62,10 @@ inline std::complex<double> dynamicalFunction(double J, double muPrime,
   return result;
 }
 
-std::shared_ptr<ComPWA::FunctionTree::TreeNode>
-createFunctionTree(double J, double MuPrime, double Mu,
-                   const ComPWA::FunctionTree::ParameterList &sample,
-                   int posTheta, int posPhi);
+std::shared_ptr<ComPWA::FunctionTree::TreeNode> createFunctionTree(
+    double J, double MuPrime, double Mu,
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>> Theta,
+    std::shared_ptr<ComPWA::FunctionTree::Value<std::vector<double>>> Phi);
 } // namespace WignerD
 
 class WignerDStrategy : public ComPWA::FunctionTree::Strategy {

--- a/Physics/SubSystem.hpp
+++ b/Physics/SubSystem.hpp
@@ -10,8 +10,10 @@
 #ifndef COMPWA_PHYSICS_SUBSYSTEM_HPP_
 #define COMPWA_PHYSICS_SUBSYSTEM_HPP_
 
-#include <boost/property_tree/ptree.hpp>
+#include <functional>
 #include <vector>
+
+#include <boost/property_tree/ptree.hpp>
 
 namespace ComPWA {
 
@@ -77,5 +79,37 @@ inline std::vector<unsigned int> stringToVectInt(std::string str) {
 
 } // namespace Physics
 } // namespace ComPWA
+
+namespace std {
+
+// this function was copied from boost
+template <typename T> std::size_t combineHash(size_t hash, const T &v) {
+  hash ^= std::hash<T>()(v) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+  return hash;
+}
+template <> struct hash<ComPWA::IndexList> {
+  std::size_t operator()(const ComPWA::IndexList &key) const {
+    std::size_t seed = key.size();
+    for (unsigned int i : key) {
+      seed = combineHash(seed, i);
+    }
+    return seed;
+  }
+};
+
+template <> struct hash<ComPWA::Physics::SubSystem> {
+  std::size_t operator()(const ComPWA::Physics::SubSystem &key) const {
+    std::size_t seed = key.getFinalStates().size();
+    for (auto const &x : key.getFinalStates()) {
+      seed = combineHash(seed, x);
+    }
+    seed = combineHash(seed, key.getRecoilState());
+    seed = combineHash(seed, key.getParentRecoilState());
+
+    return seed;
+  }
+};
+
+} // namespace std
 
 #endif

--- a/Tools/Integration.cpp
+++ b/Tools/Integration.cpp
@@ -35,11 +35,9 @@ KahanSummation KahanSum(KahanSummation accumulation, double value) {
   return result;
 }
 
-std::pair<double, double> integrateWithError(
-    ComPWA::Function<std::vector<double>, std::vector<std::vector<double>>>
-        &intensity,
-    const ComPWA::Data::DataSet &phspsample, double phspVolume) {
-
+std::pair<double, double>
+integrateWithError(ComPWA::Intensity &intensity,
+                   const ComPWA::Data::DataSet &phspsample, double phspVolume) {
   auto WeightSum =
       std::accumulate(phspsample.Weights.begin(), phspsample.Weights.end(),
                       KahanSummation{0., 0.}, KahanSum);

--- a/Tools/Plotting/DalitzPlot.cpp
+++ b/Tools/Plotting/DalitzPlot.cpp
@@ -249,7 +249,7 @@ DalitzHisto::DalitzHisto(HelicityKinematics &helkin, std::string name,
   Hists2D.insert(std::make_pair(
       std::make_pair(std::get<0>(sys12), std::get<0>(sys12)), hist2d));
 
-  for (auto x : Hists2D) {
+  for (auto &x : Hists2D) {
     x.second.GetXaxis()->SetNdivisions(508);
     x.second.GetZaxis()->SetTitle("Entries");
   }
@@ -279,14 +279,14 @@ void DalitzHisto::fill(const Data::DataSet &sample,
     weights.push_back(sample.Weights[i] * Intensities[i]);
   }
 
-  for (auto h1 : Hists1D) {
+  for (auto &h1 : Hists1D) {
     auto const &data = sample.Data.at(h1.first);
     for (size_t i = 0; i < data.size(); ++i) {
       h1.second.Fill(data[i], weights[i]);
     }
   }
 
-  for (auto h2 : Hists2D) {
+  for (auto &h2 : Hists2D) {
     auto const &data1 = sample.Data.at(h2.first.first);
     auto const &data2 = sample.Data.at(h2.first.second);
     for (size_t i = 0; i < data1.size(); ++i) {
@@ -306,25 +306,25 @@ void DalitzHisto::fill(const Data::DataSet &sample,
 }
 
 void DalitzHisto::setStats(bool b) {
-  for (auto x : Hists1D) {
+  for (auto &x : Hists1D) {
     x.second.SetStats(b);
   }
-  for (auto x : Hists2D) {
+  for (auto &x : Hists2D) {
     x.second.SetStats(b);
   }
 }
 
 void DalitzHisto::scale(double w) {
-  for (auto x : Hists1D) {
+  for (auto &x : Hists1D) {
     x.second.Scale(w);
   }
-  for (auto x : Hists2D) {
+  for (auto &x : Hists2D) {
     x.second.Scale(w);
   }
 }
 
 void DalitzHisto::setColor(Color_t color) {
-  for (auto x : Hists1D) {
+  for (auto &x : Hists1D) {
     x.second.SetLineColor(color);
     x.second.SetMarkerColor(color);
   }

--- a/Tools/Plotting/DalitzPlot.cpp
+++ b/Tools/Plotting/DalitzPlot.cpp
@@ -54,12 +54,12 @@ void DalitzPlot::fill(const std::vector<ComPWA::Event> &data, bool normalize,
                       const std::string &name, const std::string &title,
                       Color_t color) {
 
-  Data::DataSet dataset = Data::convertEventsToDataSet(data, HelKin);
+  Data::DataSet dataset = HelKin.convert(data);
 
   DalitzHisto hist(HelKin, name, title, _bins, color);
   hist.setStats(0);
 
-  hist.fill(HelKin, dataset);
+  hist.fill(dataset);
 
   if (normalize)
     _globalScale = hist.integral();
@@ -70,11 +70,11 @@ void DalitzPlot::fill(const std::vector<ComPWA::Event> &data, bool normalize,
 void DalitzPlot::fill(const std::vector<ComPWA::Event> &data, Intensity &intens,
                       bool normalize, const std::string &name,
                       const std::string &title, Color_t color) {
-  Data::DataSet dataset = Data::convertEventsToDataSet(data, HelKin);
+  Data::DataSet dataset = HelKin.convert(data);
   DalitzHisto hist(HelKin, name, title, _bins, color);
   hist.setStats(0);
   auto Intensities = intens.evaluate(dataset.Data);
-  hist.fill(HelKin, dataset, Intensities);
+  hist.fill(dataset, Intensities);
 
   if (normalize)
     _globalScale = hist.integral();
@@ -117,11 +117,11 @@ void DalitzPlot::plot() {
   TCanvas *c2 = new TCanvas("invmass", "invmass", 50, 50, 2400, 800);
   c2->Divide(3, 1);
   c2->cd(1);
-  CreateHist(0); // Plotting mKKsq
+  CreateHist("mSq_(1,2)"); // Plotting mKKsq
   c2->cd(2);
-  CreateHist(1); // Plotting mKSK+sq
+  CreateHist("mSq_(0,2)"); // Plotting mKSK+sq
   c2->cd(3);
-  CreateHist(2); // Plotting mKSK+sq
+  CreateHist("mSq_(0,1)"); // Plotting mKSK+sq
 
   //----- Write to TFile -----
   TFile *tf2 = new TFile(Name + ".root", "recreate");
@@ -148,16 +148,16 @@ void DalitzPlot::plot() {
   return;
 }
 
-void DalitzPlot::CreateHist(unsigned int id) {
+void DalitzPlot::CreateHist(std::string Name) {
   if (!_plotHistograms.size())
     return;
 
   std::vector<TH1D *> v;
   std::vector<TString> options;
-  v.push_back(_plotHistograms.at(0).getHistogram(id));
+  v.push_back(_plotHistograms.at(0).getHistogram(Name));
   options.push_back("E1");
   for (unsigned int t = 1; t < _plotHistograms.size(); ++t) {
-    v.push_back(_plotHistograms.at(t).getHistogram(id));
+    v.push_back(_plotHistograms.at(t).getHistogram(Name));
     options.push_back("Sames,Hist");
   }
 
@@ -180,84 +180,92 @@ DalitzHisto::DalitzHisto(HelicityKinematics &helkin, std::string name,
   char label[60];
 
   // mass23sq
-  unsigned int sys23(helkin.addSubSystem({1}, {2}, {0}, {}));
-  auto m23sq_limit = helkin.invMassBounds(sys23);
+  auto sys23(helkin.registerSubSystem({1}, {2}, {0}, {}));
+  auto m23sq_limit = helkin.getInvariantMassBounds(std::get<0>(sys23));
   double m23sq_min = m23sq_limit.first;
   double m23sq_max = m23sq_limit.second;
-  Arr.push_back(TH1D(TString(Name + "m23sq"), TString(Title), NumBins,
-                     m23sq_min, m23sq_max));
+  TH1D hist = TH1D(TString(Name + "m23sq"), TString(Title), NumBins, m23sq_min,
+                   m23sq_max);
   double binWidth = (double)(m23sq_min - m23sq_max) / NumBins;
   sprintf(label, "Entries /%f.3", binWidth);
-  Arr.back().GetYaxis()->SetTitle("# [" + TString(label) + "]");
-  Arr.back().GetXaxis()->SetTitle("m_{23}^{2} [GeV/c^{2}]");
-  Arr.back().Sumw2();
+  hist.GetYaxis()->SetTitle("# [" + TString(label) + "]");
+  hist.GetXaxis()->SetTitle("m_{23}^{2} [GeV/c^{2}]");
+  hist.Sumw2();
+  Hists1D.insert(std::make_pair(std::get<0>(sys23), hist));
 
   // mass13sq
-  unsigned int sys13(helkin.addSubSystem({0}, {2}, {1}, {}));
-  auto m13sq_limit = helkin.invMassBounds(sys13);
+  auto sys13(helkin.registerSubSystem({0}, {2}, {1}, {}));
+  auto m13sq_limit = helkin.getInvariantMassBounds(std::get<0>(sys13));
   double m13sq_min = m13sq_limit.first;
   double m13sq_max = m13sq_limit.second;
-  Arr.push_back(TH1D(TString(Name + "m13sq"), TString(Title), NumBins,
-                     m13sq_min, m13sq_max));
+  hist = TH1D(TString(Name + "m13sq"), TString(Title), NumBins, m13sq_min,
+              m13sq_max);
   binWidth = (double)(m13sq_min - m13sq_max) / NumBins;
   sprintf(label, "Entries /%f.3", binWidth);
-  Arr.back().GetYaxis()->SetTitle("# [" + TString(label) + "]");
-  Arr.back().GetXaxis()->SetTitle("m_{13}^{2} [GeV/c^{2}]");
-  Arr.back().Sumw2();
+  hist.GetYaxis()->SetTitle("# [" + TString(label) + "]");
+  hist.GetXaxis()->SetTitle("m_{13}^{2} [GeV/c^{2}]");
+  hist.Sumw2();
+  Hists1D.insert(std::make_pair(std::get<0>(sys13), hist));
 
   // mass12sq
-  unsigned int sys12(helkin.addSubSystem({0}, {1}, {2}, {}));
-  auto m12sq_limit = helkin.invMassBounds(sys12);
+  auto sys12(helkin.registerSubSystem({0}, {1}, {2}, {}));
+  auto m12sq_limit = helkin.getInvariantMassBounds(std::get<0>(sys12));
   double m12sq_min = m12sq_limit.first;
   double m12sq_max = m12sq_limit.second;
-  Arr.push_back(TH1D(TString(Name + "m12sq"), TString(Title), NumBins,
-                     m12sq_min, m12sq_max));
+  hist = TH1D(TString(Name + "m12sq"), TString(Title), NumBins, m12sq_min,
+              m12sq_max);
   binWidth = (double)(m12sq_min - m12sq_max) / NumBins;
   sprintf(label, "Entries /%f.3", binWidth);
-  Arr.back().GetYaxis()->SetTitle("# [" + TString(label) + "]");
-  Arr.back().GetXaxis()->SetTitle("m_{12}^{2} [GeV/c^{2}]");
-  Arr.back().Sumw2();
+  hist.GetYaxis()->SetTitle("# [" + TString(label) + "]");
+  hist.GetXaxis()->SetTitle("m_{12}^{2} [GeV/c^{2}]");
+  hist.Sumw2();
+  Hists1D.insert(std::make_pair(std::get<0>(sys12), hist));
 
-  Arr2D.push_back(TH2D(TString(name + "_m23sqm13sq"), TString(title), NumBins,
-                       m23sq_min, m23sq_max, NumBins, m13sq_min, m13sq_max));
-  Arr2D.push_back(TH2D(TString(name + "_m23sqm12sq"), TString(title), NumBins,
-                       m23sq_min, m23sq_max, NumBins, m12sq_min, m12sq_max));
-  Arr2D.push_back(TH2D(TString(name + "_m12sqm13sq"), TString(title), NumBins,
-                       m12sq_min, m12sq_max, NumBins, m13sq_min, m13sq_max));
-  Arr2D.push_back(TH2D(TString(name + "_m23sqCosTheta"), TString(title),
-                       NumBins, m23sq_min, m23sq_max, NumBins, -1, 1));
+  TH2D hist2d = TH2D(TString(name + "_m23sqm13sq"), TString(title), NumBins,
+                     m23sq_min, m23sq_max, NumBins, m13sq_min, m13sq_max);
+  hist2d.GetXaxis()->SetTitle("m_{KK}^{2} [GeV^{2}/c^{4}]");
+  hist2d.GetYaxis()->SetTitle("m_{K_{S}K^{+}}^{2} [GeV^{2}/c^{4}]");
+  Hists2D.insert(std::make_pair(
+      std::make_pair(std::get<0>(sys23), std::get<0>(sys13)), hist2d));
 
-  Arr2D.at(0).GetXaxis()->SetTitle("m_{KK}^{2} [GeV^{2}/c^{4}]");
-  Arr2D.at(0).GetYaxis()->SetTitle("m_{K_{S}K^{+}}^{2} [GeV^{2}/c^{4}]");
-  Arr2D.at(1).GetXaxis()->SetTitle("m_{KK}^{2} [GeV^{2}/c^{4}");
-  Arr2D.at(1).GetYaxis()->SetTitle("m_{K_{S}K^{-}}^{2} [GeV^{2}/c^{4}]");
-  Arr2D.at(2).GetXaxis()->SetTitle("m_{K_{S}K^{-}}^{2} [GeV^{2}/c^{4}]");
-  Arr2D.at(2).GetYaxis()->SetTitle("m_{K_{S}K^{+}}^{2} [GeV^{2}/c^{4}]");
-  Arr2D.at(3).GetXaxis()->SetTitle("m_{KK}^{2} [GeV^{2}/c^{4}]");
-  Arr2D.at(3).GetYaxis()->SetTitle("#cos(#Theta)_{KK}");
+  hist2d = TH2D(TString(name + "_m23sqm12sq"), TString(title), NumBins,
+                m23sq_min, m23sq_max, NumBins, m12sq_min, m12sq_max);
+  hist2d.GetXaxis()->SetTitle("m_{KK}^{2} [GeV^{2}/c^{4}");
+  hist2d.GetYaxis()->SetTitle("m_{K_{S}K^{-}}^{2} [GeV^{2}/c^{4}]");
+  Hists2D.insert(std::make_pair(
+      std::make_pair(std::get<0>(sys23), std::get<0>(sys12)), hist2d));
 
-  auto itr = Arr2D.begin();
-  for (; itr != Arr2D.end(); ++itr) {
-    (*itr).GetXaxis()->SetNdivisions(508);
-    (*itr).GetZaxis()->SetTitle("Entries");
+  hist2d = TH2D(TString(name + "_m12sqm13sq"), TString(title), NumBins,
+                m12sq_min, m12sq_max, NumBins, m13sq_min, m13sq_max);
+  hist2d.GetXaxis()->SetTitle("m_{K_{S}K^{-}}^{2} [GeV^{2}/c^{4}]");
+  hist2d.GetYaxis()->SetTitle("m_{K_{S}K^{+}}^{2} [GeV^{2}/c^{4}]");
+  Hists2D.insert(std::make_pair(
+      std::make_pair(std::get<0>(sys12), std::get<0>(sys13)), hist2d));
+
+  hist2d = TH2D(TString(name + "_m23sqCosTheta"), TString(title), NumBins,
+                m23sq_min, m23sq_max, NumBins, -1, 1);
+  hist2d.GetXaxis()->SetTitle("m_{KK}^{2} [GeV^{2}/c^{4}]");
+  hist2d.GetYaxis()->SetTitle("#cos(#Theta)_{KK}");
+  Hists2D.insert(std::make_pair(
+      std::make_pair(std::get<0>(sys12), std::get<0>(sys12)), hist2d));
+
+  for (auto x : Hists2D) {
+    x.second.GetXaxis()->SetNdivisions(508);
+    x.second.GetZaxis()->SetTitle("Entries");
   }
 
   setColor(color);
   return;
 }
-void DalitzHisto::fill(const HelicityKinematics &helkin,
-                       const Data::DataSet &sample) {
-  if (!sample.Data.size())
-    throw std::runtime_error("DalitzHist::fill() | Empty data sample.");
-  std::vector<double> w(sample.Weights.size(), 1.0);
-  fill(helkin, sample, w);
-}
 
-void DalitzHisto::fill(const HelicityKinematics &helkin,
-                       const Data::DataSet &sample, std::vector<double> w) {
+void DalitzHisto::fill(const Data::DataSet &sample,
+                       std::vector<double> Intensities) {
+  if (Intensities.size() == 0) {
+    Intensities = std::vector<double>(sample.Weights.size(), 1.0);
+  }
   if (!sample.Data.size())
     throw std::runtime_error("DalitzHist::fill() | Empty data sample.");
-  if (w.size() != sample.Weights.size())
+  if (Intensities.size() != sample.Weights.size())
     throw std::runtime_error("DalitzHist::fill() | Vector of weights and "
                              "sample do not have the same length");
 
@@ -266,110 +274,77 @@ void DalitzHisto::fill(const HelicityKinematics &helkin,
 
   Integral += weight;
 
-  unsigned int sysId23 =
-      helkin.getDataID(Physics::SubSystem({{1}, {2}}, {0}, {}));
-  unsigned int sysId13 =
-      helkin.getDataID(Physics::SubSystem({{0}, {2}}, {1}, {}));
-  unsigned int sysId12 =
-      helkin.getDataID(Physics::SubSystem({{0}, {1}}, {2}, {}));
+  std::vector<double> weights;
+  for (size_t i = 0; i < Intensities.size(); ++i) {
+    weights.push_back(sample.Weights[i] * Intensities[i]);
+  }
 
-  auto m23sq = sample.Data.at(3 * sysId23);
-  auto cos23 = sample.Data.at(3 * sysId23 + 1);
-  auto m13sq = sample.Data.at(3 * sysId13);
-  auto m12sq = sample.Data.at(3 * sysId12);
+  for (auto h1 : Hists1D) {
+    auto const &data = sample.Data.at(h1.first);
+    for (size_t i = 0; i < data.size(); ++i) {
+      h1.second.Fill(data[i], weights[i]);
+    }
+  }
 
-  for (size_t i = 0; i < w.size(); ++i) {
-    auto ww = sample.Weights.at(i) * w.at(i);
-    Arr.at(0).Fill(m23sq.at(i), ww);
-    Arr.at(1).Fill(m13sq.at(i), ww);
-    Arr.at(2).Fill(m12sq.at(i), ww);
+  for (auto h2 : Hists2D) {
+    auto const &data1 = sample.Data.at(h2.first.first);
+    auto const &data2 = sample.Data.at(h2.first.second);
+    for (size_t i = 0; i < data1.size(); ++i) {
+      h2.second.Fill(data1[i], data2[i], weights[i]);
+    }
+  }
 
-    Arr2D.at(0).Fill(m23sq.at(i), m13sq.at(i), ww);
-    Arr2D.at(1).Fill(m23sq.at(i), m12sq.at(i), ww);
-    Arr2D.at(2).Fill(m12sq.at(i), m13sq.at(i), ww);
-    Arr2D.at(3).Fill(m23sq.at(i), cos23.at(i), ww);
-    BranchPoint = {m23sq.at(i), m13sq.at(i), m12sq.at(i)};
-    BranchWeight = ww;
+  auto const &m23sq = sample.Data.at("mSq_(1,2)");
+  auto const &m13sq = sample.Data.at("mSq_(0,2)");
+  auto const &m12sq = sample.Data.at("mSq_(0,1)");
+  for (size_t i = 0; i < weights.size(); ++i) {
+    BranchPoint = {m23sq[i], m13sq[i], m12sq[i]};
+    BranchWeight = weights[i];
     BranchEff = 1.0;
     Tree->Fill();
   }
 }
 
-void DalitzHisto::fill(const HelicityKinematics &helkin, const DataPoint &point,
-                       double w) {
-  double weight = point.Weight * w; // use event weights?
-
-  Integral += weight;
-
-  unsigned int sysId23 =
-      helkin.getDataID(Physics::SubSystem({{1}, {2}}, {0}, {}));
-  unsigned int sysId13 =
-      helkin.getDataID(Physics::SubSystem({{0}, {2}}, {1}, {}));
-  unsigned int sysId12 =
-      helkin.getDataID(Physics::SubSystem({{0}, {1}}, {2}, {}));
-
-  double m23sq = point.KinematicVariableList[3 * sysId23];
-  double cos23 = point.KinematicVariableList[3 * sysId23 + 1];
-  double m13sq = point.KinematicVariableList[3 * sysId13];
-  //  double cos13 = point.getVal(3*sysId13+1);
-  double m12sq = point.KinematicVariableList[3 * sysId12];
-  //  double cos12 = point.getVal(3*sysId12+1);
-
-  Arr.at(0).Fill(m23sq, weight);
-  Arr.at(1).Fill(m13sq, weight);
-  Arr.at(2).Fill(m12sq, weight);
-
-  Arr2D.at(0).Fill(m23sq, m13sq, weight);
-  Arr2D.at(1).Fill(m23sq, m12sq, weight);
-  Arr2D.at(2).Fill(m12sq, m13sq, weight);
-  Arr2D.at(3).Fill(m23sq, cos23, weight);
-}
-
 void DalitzHisto::setStats(bool b) {
-  auto n = Arr.size();
-  for (unsigned int i = 0; i < n; ++i) {
-    Arr.at(i).SetStats(b);
+  for (auto x : Hists1D) {
+    x.second.SetStats(b);
   }
-  auto n2 = Arr2D.size();
-  for (unsigned int i = 0; i < n2; ++i) {
-    Arr2D.at(i).SetStats(b);
+  for (auto x : Hists2D) {
+    x.second.SetStats(b);
   }
 }
 
 void DalitzHisto::scale(double w) {
-  auto n = Arr.size();
-  for (unsigned int i = 0; i < n; ++i) {
-    Arr.at(i).Scale(w);
+  for (auto x : Hists1D) {
+    x.second.Scale(w);
   }
-  auto n2 = Arr2D.size();
-  for (unsigned int i = 0; i < n2; ++i) {
-    Arr2D.at(i).Scale(w);
+  for (auto x : Hists2D) {
+    x.second.Scale(w);
   }
 }
 
 void DalitzHisto::setColor(Color_t color) {
-  auto n = Arr.size();
-  for (unsigned int i = 0; i < n; ++i) {
-    Arr.at(i).SetLineColor(color);
-    Arr.at(i).SetMarkerColor(color);
+  for (auto x : Hists1D) {
+    x.second.SetLineColor(color);
+    x.second.SetMarkerColor(color);
   }
 }
 
-TH1D *DalitzHisto::getHistogram(unsigned int num) { return &Arr.at(num); }
+TH1D *DalitzHisto::getHistogram(std::string Name) { return &Hists1D.at(Name); }
 
-TH2D *DalitzHisto::getHistogram2D(unsigned int num) { return &Arr2D.at(num); }
+TH2D *DalitzHisto::getHistogram2D(std::pair<std::string, std::string> Names) {
+  return &Hists2D.at(Names);
+}
 
 void DalitzHisto::write() {
   Tree->Write(TString(Name) + "Tree");
   gDirectory->mkdir(TString(Name) + "_hist");
   gDirectory->cd(TString(Name) + "_hist");
-  auto n = Arr.size();
-  for (unsigned int i = 0; i < n; ++i) {
-    Arr.at(i).Write();
+  for (auto const &x : Hists1D) {
+    x.second.Write();
   }
-  auto n2 = Arr2D.size();
-  for (unsigned int i = 0; i < n2; ++i) {
-    Arr2D.at(i).Write();
+  for (auto const &x : Hists2D) {
+    x.second.Write();
   }
   gDirectory->cd("../");
 }

--- a/Tools/Plotting/DalitzPlot.hpp
+++ b/Tools/Plotting/DalitzPlot.hpp
@@ -5,6 +5,7 @@
 #ifndef PLOTDATA_HPP_
 #define PLOTDATA_HPP_
 
+#include <map>
 #include <vector>
 
 #include <TGraph.h>
@@ -43,7 +44,7 @@ public:
   DalitzHisto(const DalitzHisto &that) = delete;
 
   /// Default move constructor
-  DalitzHisto(DalitzHisto &&other) = default; // C++11 move constructor
+  DalitzHisto(DalitzHisto &&other) = default;
 
   DalitzHisto(ComPWA::Physics::HelicityFormalism::HelicityKinematics &helkin,
               std::string name, std::string title, unsigned int bins,
@@ -51,23 +52,15 @@ public:
   /// Switch on/off stats
   void setStats(bool b);
 
-  void
-  fill(const ComPWA::Physics::HelicityFormalism::HelicityKinematics &helkin,
-       const ComPWA::Data::DataSet &sample);
+  void fill(const ComPWA::Data::DataSet &sample,
+            std::vector<double> Intensities = {});
 
-  void
-  fill(const ComPWA::Physics::HelicityFormalism::HelicityKinematics &helkin,
-       const ComPWA::Data::DataSet &sample, std::vector<double> w);
-
-  /// Fill event
-  void fill(const ComPWA::Physics::HelicityFormalism::HelicityKinematics &kin,
-            const ComPWA::DataPoint &point, double w = 1.0);
   /// Scale all distributions
   void scale(double w);
   /// Get 1D histogram
-  TH1D *getHistogram(unsigned int num);
+  TH1D *getHistogram(std::string Name);
   /// Get 2D histogram
-  TH2D *getHistogram2D(unsigned int num);
+  TH2D *getHistogram2D(std::pair<std::string, std::string> Names);
   /// set line color
   void setColor(Color_t color);
   /// Write to TFile
@@ -76,8 +69,8 @@ public:
   double integral() { return Integral; }
 
 private:
-  std::vector<TH1D> Arr;
-  std::vector<TH2D> Arr2D;
+  std::map<std::string, TH1D> Hists1D;
+  std::map<std::pair<std::string, std::string>, TH2D> Hists2D;
   std::string Name, Title;
   unsigned int NumBins;
 
@@ -115,7 +108,7 @@ private:
 
   double _globalScale;
 
-  void CreateHist(unsigned int id);
+  void CreateHist(std::string Name);
 
   std::vector<DalitzHisto> _plotHistograms;
 };

--- a/Tools/test/SaveAndLoadFitResultTest.cpp
+++ b/Tools/test/SaveAndLoadFitResultTest.cpp
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(SaveAndLoadFitResultTest) {
   // auto [Esti, Parameters] = ...
   auto EstimatorParametersTuple =
       ComPWA::Estimator::createMinLogLHFunctionTreeEstimator(
-          ModelIntensity, Data::convertEventsToDataSet(DataSample, DecayKin));
+          ModelIntensity, DecayKin.convert(DataSample));
   FitParameterList &Parameters(std::get<1>(EstimatorParametersTuple));
 
   ComPWA::FunctionTree::FunctionTreeEstimator &Esti(


### PR DESCRIPTION
This is not completely finished yet. So some cleanup work has still to be done, but the big changes are finished.

The main parts that changed:
* DataSet now has an `unordered_map` of the individual data vectors (instead of a vector)
* The Intensity interface now also expect this map as input
* The kinematics interface was also adapted to process this new data format
* The helicity kinematics class was reworked, as foundation work for the fix of the break up momenta.
Variables are now separated into angles and invariant masses and uniquely defined by their name. The name also allows easy access from the returned DataSet.