### PR TITLE
fix: remove progress bar from phsp generation

### DIFF
--- a/Data/EvtGen/EvtGenGenerator.cpp
+++ b/Data/EvtGen/EvtGenGenerator.cpp
@@ -4,7 +4,6 @@
 
 #include "EvtGenGenerator.hpp"
 
-#include "Core/ProgressBar.hpp"
 #include "Core/Properties.hpp"
 #include "Core/Random.hpp"
 #include "Physics/ParticleStateTransitionKinematicsInfo.hpp"
@@ -43,7 +42,6 @@ EvtGenGenerator::generate(unsigned int NumberOfEvents,
 
   EventCollection GeneratedPhsp{FinalStatePIDs};
 
-  ComPWA::ProgressBar bar(NumberOfEvents);
   for (unsigned int i = 0; i < NumberOfEvents; ++i) {
     std::vector<EvtVector4R> FourVectors(FinalStateMasses.size());
 
@@ -66,7 +64,6 @@ EvtGenGenerator::generate(unsigned int NumberOfEvents,
     // Reset weights: weights are taken into account by hit&miss. The
     // resulting sample is therefore unweighted
     GeneratedPhsp.Events.push_back(ComPWA::Event{FourMomenta, 1.0});
-    bar.next();
   }
   return GeneratedPhsp;
 }

--- a/Data/Generate.cpp
+++ b/Data/Generate.cpp
@@ -117,6 +117,8 @@ EventCollection generate(unsigned int NumberOfEvents,
     EventCollection TempEvents =
         Generator.generate(EventBunchSize, RandomGenerator);
 
+    TotalGeneratedEvents += EventBunchSize;
+
     auto Bunch =
         generateBunch(EventBunchSize, Kinematics, Intensity, RandomGenerator,
                       generationMaxValue, TempEvents.Events.begin(),

--- a/Data/Root/RootGenerator.cpp
+++ b/Data/Root/RootGenerator.cpp
@@ -6,7 +6,6 @@
 
 #include "Core/Event.hpp"
 #include "Core/Logging.hpp"
-#include "Core/ProgressBar.hpp"
 #include "Core/Properties.hpp"
 #include "Core/Random.hpp"
 #include "Physics/ParticleStateTransitionKinematicsInfo.hpp"
@@ -216,14 +215,6 @@ double RootGenerator::PDK(double a, double b, double c) const {
   double x = (a - b - c) * (a + b + c) * (a - b + c) * (a + b - c);
   return std::sqrt(x) / (2.0 * a);
 }
-
-/*
-ComPWA::Event UniformTwoBodyGenerator::generate() {
-  double s = RootGenerator::uniform(minSq, maxSq);
-  CMSP4 = ComPWA::FourMomentum(0.0, 0.0, 0.0, std::sqrt(s));
-  init();
-  return RootGenerator::generate();
-}*/
 
 } // namespace Root
 } // namespace Data


### PR DESCRIPTION
This is related to the bunching used in the event generation, which will
create unnecessary log output.