### PR TITLE
feat: add façade functions for kinematics

### DIFF
--- a/Physics/BuilderXML.hpp
+++ b/Physics/BuilderXML.hpp
@@ -139,6 +139,17 @@ private:
   DataContainer PhspRecoData;
 };
 
+/// Create HelicityKinematics object from an XML file that contains both a
+/// kinematics section and a particle section
+HelicityFormalism::HelicityKinematics
+createHelicityKinematics(const std::string XmlFile);
+
+/// Create HelicityKinematics object from an XML file with a kinematics section
+/// and provide a particle list separately.
+HelicityFormalism::HelicityKinematics
+createHelicityKinematics(const ComPWA::ParticleList &PartList,
+                         const std::string XmlFile);
+
 HelicityFormalism::HelicityKinematics
 createHelicityKinematics(const ComPWA::ParticleList &PartList,
                          const boost::property_tree::ptree &pt);


### PR DESCRIPTION
Added two more functions to the BuilderXML that allow one to directly create a kinematics instance from an XML file (i.e. without first having to create a particle list instance). This addresses https://github.com/ComPWA/pycompwa/pull/78#discussion_r408274289