### PR TITLE
ci: standardize local developer tools

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -2,7 +2,7 @@
 # This while was tested with cmake-format 0.6.9
 
 # In a UNIX system, you can format all ComPWA files with
-# cmake-format --config-file .cmake-format -i $(find -type f -name CMakeLists.txt ! -wholename "./ThirdParty/*")
+# cmake-format --config-file .cmake-format -i $(find -type f -name CMakeLists.txt ! -wholename "./ThirdParty/*/CMakeLists.txt")
 
 enable_markup: False # should be True if comments are explanations only
 first_comment_is_literal: True

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+
+[*.{json,yaml,yml,C,cpp,hpp,xml}]
+indent_size = 2
+
+[Makefile]
+indent_size = 4
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,40 +1,53 @@
+# Temporary files
 .DS_Store
-*.root
-*.so
-*.o
-*.d
 ~*
-bin/
-lib/
-external
-*.project
+*~
+
+# XCode
 *.cproject
 *.prefs
+*.project
 .settings/
-test/.settings/
-Physics/particles.xml
-Physics/physConstants.xml
-doc/doxygen/
+
+# C++
 *Dict.hpp
 *Dict.h
 *Dict.cxx
 *Dict.cpp
-build.cfg
+
 /Default/
-build
-dist
-*egg-info
-install
-*.env
-*.vscode
-*.pydevproject
-*__pycache__
-.pytest_cache
-python-venv/
-*.png
+# Build folders
+*.a
+*.d
+*.o
+*.so
+*build/
+*install/
+bin/
+build.cfg
+lib/
+
+# Data files
 *.log
+*.png
+*.root
+Physics/particles.xml
+Physics/physConstants.xml
+
+# CMake
 *Config.cmake
 *ConfigVersion.cmake
-*ipynb_checkpoints
-.vscode/
+
+# Python
+*.env
+*.pydevproject
+*__pycache__
+*egg-info/
+*ipynb_checkpoints/
+*venv/
+.pytest_cache/
+dist
+
+# Visual Studio Code
 *.code-workspace
+.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+
+  - repo: local
+    hooks:
+      - id: clang-format
+        name: clang-format
+        entry: clang-format
+        language: system
+        types:
+          - c++
+
+      - id: cmake-format
+        name: cmake-format
+        entry: cmake-format -i
+        language: python
+        types:
+          - cmake

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Test coverage](https://codecov.io/gh/ComPWA/ComPWA/branch/master/graph/badge.svg)](https://codecov.io/gh/ComPWA/ComPWA)
 [![CodeFactor](https://www.codefactor.io/repository/github/compwa/compwa/badge)](https://www.codefactor.io/repository/github/compwa/compwa)
 [![Coverity](https://scan.coverity.com/projects/13697/badge.svg)](https://scan.coverity.com/projects/compwa-compwa)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 ![ComPWA Logo](https://github.com/ComPWA/ComPWA/blob/master/doc/images/logo.png)
 

--- a/ThirdParty/CMakeLists.txt
+++ b/ThirdParty/CMakeLists.txt
@@ -1,15 +1,21 @@
 # Get system-wide TBB
-# System-wide search must be commented out here since pstl's 
-# FindTBB.cmake is buggy and does not work if find_package( TBB ) 
-# were called before 
+# System-wide search must be commented out here since pstl's
+# FindTBB.cmake is buggy and does not work if find_package( TBB )
+# were called before
 #find_package( TBB 2018 )
 
 # If no system-wide version is found, use the local one
 if(NOT TBB_FOUND)
   message(STATUS "System-wide TBB not found. Use local one.")
-  set(TBB_BUILD_TESTS OFF CACHE BOOL "")
-  set(TBB_BUILD_STATIC OFF CACHE BOOL "")
-  set(TBB_BUILD_SHARED ON CACHE BOOL "")
+  set(TBB_BUILD_TESTS
+      OFF
+      CACHE BOOL "")
+  set(TBB_BUILD_STATIC
+      OFF
+      CACHE BOOL "")
+  set(TBB_BUILD_SHARED
+      ON
+      CACHE BOOL "")
   add_subdirectory(tbb)
 
   # We do not care about compiler warnings of thirdparty dependencies
@@ -17,27 +23,31 @@ if(NOT TBB_FOUND)
   target_compile_options(tbbmalloc PRIVATE "-w")
   target_compile_options(tbbmalloc_proxy PRIVATE "-w")
 
-  # The fork github.com/wjakob/tbb does unfortunatly not properly export 
+  # The fork github.com/wjakob/tbb does unfortunatly not properly export
   # its targets
   add_library(TBB::tbb ALIAS tbb)
   add_library(TBB::tbbmalloc ALIAS tbbmalloc)
   add_library(TBB::tbbmalloc_proxy ALIAS tbbmalloc_proxy)
-  export(TARGETS tbb tbbmalloc tbbmalloc_proxy
-    NAMESPACE TBB:: FILE ${CMAKE_CURRENT_BINARY_DIR}/TBBConfig.cmake)
+  export(
+    TARGETS tbb tbbmalloc tbbmalloc_proxy
+    NAMESPACE TBB::
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/TBBConfig.cmake)
 
   # The export command above is executed after(!) find_package. Therefore we
-  # have to create a dummy TBBConfig.cmake file to fool find_library. This 
+  # have to create a dummy TBBConfig.cmake file to fool find_library. This
   # will be overwritten later
   file(WRITE ${CMAKE_BINARY_DIR}/ThirdParty/tbb/TBBConfig.cmake "")
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
-    ${CMAKE_BINARY_DIR}/ThirdParty/tbb/TBBConfigVersion.cmake 
+    ${CMAKE_BINARY_DIR}/ThirdParty/tbb/TBBConfigVersion.cmake
     VERSION 2019.0
     COMPATIBILITY AnyNewerVersion)
 
   # We need to set some variables in order to trick the CONFIG mode of pstl's
   # FindTBB.cmake
-  set(TBB_DIR ${CMAKE_BINARY_DIR}/ThirdParty/tbb CACHE PATH "")
+  set(TBB_DIR
+      ${CMAKE_BINARY_DIR}/ThirdParty/tbb
+      CACHE PATH "")
   set(TBB_IMPORTED_TARGETS "TBB::tbb;TBB::tbbmalloc;TBB::tbbmalloc_proxy")
   set(TBB_tbb_FOUND TRUE)
   set(TBB_tbbmalloc_FOUND TRUE)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,6 +18,10 @@
    :alt: Code quality
    :target: https://scan.coverity.com/projects/compwa-compwa
 
+.. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
+   :target: https://github.com/pre-commit/pre-commit
+   :alt: pre-commit
+
 |
 
 Common Partial-Wave-Analysis Framework (ComPWA)

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: compwa
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.5
+  - pip
+  - pip:
+      - -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 -r doc/requirements.txt
 black>=19.10b0
+clang-format>=0.6.8
+pre-commit>=2.2


### PR DESCRIPTION
Split from https://github.com/ComPWA/ComPWA/pull/315 because of the eventual squashed commit. Adds:

* EditorConfig
* Pre-Commit (cmake-format and clang-format)
* Conda environtment config (for pre-commit)